### PR TITLE
docs: comprehensive documentation refresh for v1.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+This changelog summarizes notable, user-facing changes per release.  It is curated
+from the project's commit history; the canonical list of releases and downloadable
+wheels lives on the [Releases page](https://github.com/cajigaslab/Thalamus/releases).
+
+Thalamus uses `MAJOR.MINOR.PATCH` versions.  Releases are produced automatically, so
+some patch versions contain only build/CI or internal changes and are omitted below.
+
+## 1.0.x
+
+### 1.0.15 — 2026-06-02
+- Eye calibration: added undo/redo.
+- Fixed an OCULOMATIC crash when the X/Y gain was a floating-point value.
+- Added a `registry` module for editing Thalamus state.
+
+### 1.0.14 — 2026-06-01
+- Recordings now save the build type, git commit, and git version tag; each task is
+  copied into the output directory the first time it executes in a recording.
+- Eye calibration moved into its own module, with point nudging and pinned-point
+  drawing in the angular-scaling view.
+- Angular scaling can now scale X and Y independently, with a crosshair overlay.
+- Added a projective-model calibrator and a code switch to toggle between the
+  OpenGL and regular Qt task widgets.
+- OCULOMATIC now tracks the pupil with doubles instead of ints.
+- Plugins can now read analog data from other nodes.
+- Fixed a duplicate-observer bug that could cause clients to receive duplicate
+  delete events, and fixed restoring the pipeline/task-controller window geometry.
+
+### 1.0.12 — 2026-05-18
+- `.NET` bindings are now built in CI.
+- The NIDAQ integration loads any version of `libnidaqmx.so`.
+- `DataFrameBuilder` gained an option to warn (instead of raising) on inconsistent
+  sample intervals.
+
+### 1.0.5 — 2026-05-04
+- Added an HTTP 1.1 + WebSocket interface.
+- Added Emscripten (WebAssembly) build support.
+- Added node sorting and filtering in the UI.
+- Added the SAMPLE_MONITOR node (with a configurable interval) for watching node
+  sample rates.
+- Added an "About Thalamus" dialog showing build info, and a sequence number to
+  `StorageRecord`.
+- Added the `thalamus.video_writer` module and `get_paths` on `MultiVideoReader`.
+- Added the CECI stimulation extension.
+- Added pthread policy/priority configuration on Linux.
+
+### 1.0.1 — 2026-04-07
+- Rewrote and hardened the Rust API (pattern-matching state API, generic
+  `on_change` callbacks, safer plugin surface).
+- Plugin multithreading; plugin data exchange now uses pointers, with error-message
+  access from plugins.
+- Added a Go node demo and finished the `EXT_SERIAL` node (reads from a pty).
+- Fixed PyQt6 compatibility issues and a freeze when creating a log stream.
+- `VideoWriter` can use a custom FFmpeg invocation.
+
+### 1.0.6–1.0.11, 1.0.13 — 2026-05
+- Build, packaging, and CI fixes (Windows/macOS/Linux toolchains, clang/LLVM
+  version handling, CMake Python-executable option, `asyncio.run` startup).
+
+## 0.3.x and earlier
+
+The 0.3.x series and earlier predate this curated changelog.  See the
+[Releases page](https://github.com/cajigaslab/Thalamus/releases) for the full tag
+history and downloadable builds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,140 @@
+# Contributing to Thalamus
+
+Thanks for your interest in improving Thalamus! This guide explains how the
+project is organized, how to set up a development environment, and how to get
+your changes merged.
+
+Thalamus is open-source under the [GPL-3.0 license](LICENSE). By contributing you
+agree that your contributions are licensed under the same terms.
+
+## Ways to contribute
+
+- **Report bugs and request features** via the [Issues](https://github.com/cajigaslab/Thalamus/issues) tab.
+- **Improve the documentation** (the [`docs/`](docs/) site, the [`README`](README.md), or the runnable [`examples/`](examples/)).
+- **Contribute code** — new node types, bug fixes, performance work, or new analysis tooling.
+
+If you are planning a substantial change, please open an issue first to discuss
+the approach before investing significant effort.
+
+## Repository layout
+
+| Path | Contents |
+| --- | --- |
+| [`thalamus/`](thalamus/) | The Python package (importable as `thalamus`). CLI entry points: `pipeline`, `task_controller`, `hydrate`, `dataframe`, `record_reader2`. |
+| [`thalamus/pipeline/`](thalamus/pipeline/) | The Qt UI: the main window and the per-node configuration widgets (`*_widget.py`). |
+| [`src/thalamus/`](src/thalamus/) | The native C++ implementation of the nodes (one `*_node.cpp` per node type). |
+| [`proto/`](proto/) | Protocol Buffer / gRPC definitions shared by the C++ and Python sides. |
+| [`docs/`](docs/) | The Sphinx documentation source. |
+| [`examples/`](examples/) | Runnable, hardware-free example scripts. |
+| [`SimpleUseCase/`](SimpleUseCase/) | Worked use cases and the analyses behind the paper's figures. |
+
+## Setting up a development environment
+
+How much you need to build depends on what you are changing.
+
+### Documentation- or pure-Python-only changes
+
+You do **not** need to build the native extension. Install a released wheel into a
+virtual environment and work against it:
+
+```
+python -m venv venv-thalamus
+source venv-thalamus/bin/activate        # Windows: call venv-thalamus/scripts/activate
+python -m pip install thalamus_neuro
+```
+
+To build the documentation locally:
+
+```
+python -m pip install sphinx sphinxcontrib-video
+python -m sphinx -b html docs/source docs/_build
+```
+
+### Building from source (native changes)
+
+Building the native extension requires a C++ toolchain, CMake (≥ 3.16), Ninja, and
+NASM, plus several third-party libraries. The `prepare.py` script bootstraps these
+dependencies for Linux, Windows, and macOS:
+
+```
+python -m venv pyenv
+source pyenv/bin/activate
+python prepare.py            # installs/bootstraps the build toolchain and deps
+# On Linux/macOS prepare.py writes environment setup to ~/.thalamusrc:
+source ~/.thalamusrc
+python -m build -n -w -Crelease
+python -m pip install dist/thalamus_neuro-*.whl
+```
+
+The build uses the custom `thalamus.build` backend declared in
+[`pyproject.toml`](pyproject.toml); protobuf/gRPC stubs are generated automatically
+during the build from the files in `proto/`. Use `-Crelease` for an optimized build.
+
+## Running Thalamus
+
+```
+python -m thalamus.pipeline          # data pipeline (no task controller)
+python -m thalamus.task_controller   # data pipeline and task controller
+```
+
+See the [Quick Start](https://cajigaslab.github.io/Thalamus/quickstart.html) for a
+guided walkthrough.
+
+## Adding a new node type
+
+Nodes are the unit of extension. A new node generally involves:
+
+1. **C++ node** in `src/thalamus/`: implement the node and give it a unique
+   `type_name()` (the string shown in the node-type dropdown). Register it with the
+   node graph so it can be instantiated.
+2. **Python widget** (optional) in `thalamus/pipeline/`: a `*_widget.py` that
+   renders the node's configuration UI, and an entry in the `FACTORY` map in
+   `thalamus/pipeline/thalamus_window.py` mapping the type name to the widget and
+   its inline property columns.
+3. **Documentation**: add a page under `docs/source/nodes/` and link it from
+   `docs/source/nodes/index.rst` and the catalog (`docs/source/nodes/catalog.rst`).
+
+Keep configuration field names stable. If a change to a node's config fields would
+break existing saved configurations, prefer creating a new numbered node (e.g.
+`STORAGE` → `STORAGE2`) rather than breaking the old one.
+
+## Changing the data format / protocol
+
+The wire and file formats are defined in `proto/`. If you modify a `.proto`,
+remember that both the C++ and Python sides consume it, and that the `.tha` capture
+format must stay backward compatible so existing recordings remain readable.
+
+## Documentation contributions
+
+- Keep documentation **congruent with the code**. Property names and behavior
+  described on a node page should match the node's widget and C++ source.
+- Example scripts in `examples/` should actually run; please execute them before
+  submitting.
+- Build the docs locally (see above) and confirm there are no Sphinx warnings for
+  the pages you touched.
+
+## Pull requests
+
+1. Fork the repository and create a topic branch for your change.
+2. Keep each PR focused on a single concern; include a clear description of what
+   changed and why.
+3. Open the PR against the repository's default branch (unless a maintainer directs
+   otherwise).
+4. **Do not bump the version or create release tags** in your PR — releases are
+   produced automatically (see below).
+
+## Versioning and releases
+
+- The version lives in [`pyproject.toml`](pyproject.toml) and follows semantic
+  versioning. `bump.py {major,minor,patch}` increments it and creates the matching
+  `vX.Y.Z` git tag.
+- Continuous integration (GitHub Actions workflows in
+  [`.github/workflows/`](.github/workflows/)) builds the Linux, Windows, and macOS
+  wheels and publishes them to the [Releases](https://github.com/cajigaslab/Thalamus/releases)
+  page. Version bumping is performed by CI, so contributors should not do it by hand.
+
+## Citation
+
+If you use Thalamus in your research, please cite our paper:
+
+> *Thalamus: a real-time, closed-loop platform for synchronized multimodal data acquisition.* Communications Engineering (Nature). https://www.nature.com/articles/s44172-026-00646-z

--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ Approximately 1 hour set-up time.
 The code repository for Thalamus is hosted on GitHub at https://github.com/cajigaslab/thalamus. Detailed documentation lives at https://cajigaslab.github.io/Thalamus/:
 
 - [Quick Start](https://cajigaslab.github.io/Thalamus/quickstart.html) — install, build a pipeline, record, and analyze your first dataset.
+- [Concepts and Architecture](https://cajigaslab.github.io/Thalamus/concepts.html) — the node pipeline, data model, capture-file format, and tooling.
 - [Examples](https://cajigaslab.github.io/Thalamus/examples/index.html) — runnable, copy-paste tutorials (including a hardware-free walkthrough).
 - [Node Reference](https://cajigaslab.github.io/Thalamus/nodes/index.html) — catalog of every node type and its configuration.
+
+Release history is recorded in [CHANGELOG.md](CHANGELOG.md).
 
 Runnable example scripts also live in the [`examples/`](examples/) folder of this repository.  For the figures in our paper, refer to the [`SimpleUseCase`](SimpleUseCase/) folder.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Thalamus
 
-Thalamus is an open-source Python program designed for real-time, synchronized, closed-loop multimodal data capture, specifically tailored to meet the stringent demands of neurosurgical environments.
+Thalamus is an open-source program designed for real-time, synchronized, closed-loop multimodal data capture, specifically tailored to meet the stringent demands of neurosurgical environments.
+
+📖 **Full documentation:** https://cajigaslab.github.io/Thalamus/
+📦 **Downloads / releases:** https://github.com/cajigaslab/Thalamus/releases
+📰 **Published paper:** [*Thalamus: a real-time, closed-loop platform for synchronized multimodal data acquisition* (Communications Engineering, Nature)](https://www.nature.com/articles/s44172-026-00646-z)
 
 # Overview
 Thalamus facilitates the advancement of clinical applications of Brain-Computer Interface (BCI) technology by integrating behavioral and electrophysiological data streams. Thalamus prioritizes the following design requirements:
@@ -15,49 +19,76 @@ Thalamus facilitates the advancement of clinical applications of Brain-Computer 
 9. Embodies best practice in software engineering using unit tests and validation checks​
 10. Supports advances in translational applications and, hence, also operates in research domains​
 
+## How it works
+
+Thalamus is built around a **pipeline of nodes**.  Each node is a small, configurable unit that either *generates* data (e.g. a hardware acquisition device or signal generator), *consumes* data (e.g. disk storage), *transforms* data (e.g. eye tracking, math expressions, coordinate mapping), or *controls* the pipeline (e.g. starting/stopping groups of nodes).  You assemble an experiment by adding nodes, configuring them, and subscribing consumers to the producers they care about.  See the [Node Reference](https://cajigaslab.github.io/Thalamus/nodes/index.html) for the full catalog of node types.
+
+Recorded data is written to a compact `.tha` capture file and can be converted to analysis-friendly formats (HDF5, CSV, Parquet, etc.) with the bundled tooling.
+
 # System Requirements
 ## Hardware Requirements
 Thalamus requires only a standard computer with enough RAM to support the in-memory operations.
-External hardware devices for data aquisition are dependent on the goals of individual projects.
+External hardware devices for data acquisition are dependent on the goals of individual projects.
 
 ## Software Requirements
-Thalamus requires Python.
+Thalamus requires Python 3.10 or newer.  Drivers and runtimes for integration with third party devices (e.g. GenTL/GenICam cameras, National Instruments DAQs) must be installed separately.
 
 ### OS Requirements
-We provide auto builds for Linux (glibc 2.35) and Windows (10).
+We provide auto builds for **Linux** (manylinux), **Windows** (10+), and **macOS** (arm64).
 
 ### Python Dependencies
-**requirements.txt** includes required dependencies if installing from Github. However, all dependencies have been packaged into the auto builds.
+**requirements.txt** lists the dependencies needed when installing from source.  The published wheels bundle all required dependencies.
 
 # Installation Guide
 ## Install from Build
-Download appropriate (Windows or Linux) build directly from actions tab or under Releases.
+Download the appropriate wheel for your platform from the [Releases](https://github.com/cajigaslab/Thalamus/releases) page (or the Actions tab).  The package is published as `thalamus_neuro`; the importable module remains `thalamus`.
 
-For Windows:
+We recommend installing into a virtual environment so the bundled `grpc` version is not disturbed:
 
-```python -m pip install thalamus-0.3.0-py3-none-win_amd64.whl```
+```
+python -m venv venv-thalamus
+# Linux/macOS
+source venv-thalamus/bin/activate
+# Windows
+call venv-thalamus/scripts/activate
+```
 
-For Linux:
+Then install the wheel for your platform, for example:
 
-```python -m pip install thalamus-0.3.0-py3-none-manylunux_2_27.whl```
+```
+# Linux
+python -m pip install thalamus_neuro-1.0.15-py3-none-manylinux_2_39_x86_64.whl
+# Windows
+python -m pip install thalamus_neuro-1.0.15-py3-none-win_amd64.whl
+# macOS (arm64)
+python -m pip install thalamus_neuro-1.0.15-py3-none-macosx_12_0_arm64.whl
+```
 
-You should now be able to run any of the Thalamus tools
+You should now be able to run any of the Thalamus tools:
 
-```python -m thalamus.pipeline # Data pipeline, no task controller```
+```
+python -m thalamus.pipeline          # Data pipeline (no task controller)
+python -m thalamus.task_controller   # Data pipeline and task controller
+python -m thalamus.hydrate FILE      # Convert a .tha capture file to HDF5
+python -m thalamus.dataframe ...      # Export a node's data to CSV/Parquet/etc.
+python -m thalamus.record_reader2 FILE  # Inspect the contents of a .tha file
+```
 
-```python -m thalamus.task_controller # Data pipeline and task controller```
+Approximately 1 hour set-up time.
 
-```python -m thalamus.hydrate # Convert capture files to sharable formats```
+# Documentation
+The code repository for Thalamus is hosted on GitHub at https://github.com/cajigaslab/thalamus. Detailed documentation lives at https://cajigaslab.github.io/Thalamus/:
 
-Approximately 1 hour set-up time
+- [Quick Start](https://cajigaslab.github.io/Thalamus/quickstart.html) — install, build a pipeline, record, and analyze your first dataset.
+- [Examples](https://cajigaslab.github.io/Thalamus/examples/index.html) — runnable, copy-paste tutorials (including a hardware-free walkthrough).
+- [Node Reference](https://cajigaslab.github.io/Thalamus/nodes/index.html) — catalog of every node type and its configuration.
 
-
-# Documentaton
-The code respository for Thalamus is hosted on GitHub at https://github.com/cajigaslab/thalamus. For detailed documentation of Thalamus visit https://cajigaslab.github.io/Thalamus/.
-For additional examples and generation of figures in our paper, refer to the **SimpleUseCase** folder in the repo.
+Runnable example scripts also live in the [`examples/`](examples/) folder of this repository.  For the figures in our paper, refer to the [`SimpleUseCase`](SimpleUseCase/) folder.
 
 # License
-If you use Thalamus in your work, please remember to cite the repository in any publications.
+Thalamus is released under the GPL-3.0 license (see [LICENSE](LICENSE)). If you use Thalamus in your work, please cite our paper:
+
+> *Thalamus: a real-time, closed-loop platform for synchronized multimodal data acquisition.* Communications Engineering (Nature). https://www.nature.com/articles/s44172-026-00646-z
 
 # Issues
 Like all open-source projects, Thalamus will benefit from your involvement, suggestions and contributions. This platform is intended as a repository for extensions to the program based on your code contributions as well as for flagging and tracking open issues. Please use the **Issues** tab as fit.

--- a/README.md
+++ b/README.md
@@ -90,5 +90,7 @@ Thalamus is released under the GPL-3.0 license (see [LICENSE](LICENSE)). If you 
 
 > *Thalamus: a real-time, closed-loop platform for synchronized multimodal data acquisition.* Communications Engineering (Nature). https://www.nature.com/articles/s44172-026-00646-z
 
-# Issues
-Like all open-source projects, Thalamus will benefit from your involvement, suggestions and contributions. This platform is intended as a repository for extensions to the program based on your code contributions as well as for flagging and tracking open issues. Please use the **Issues** tab as fit.
+# Contributing
+Like all open-source projects, Thalamus will benefit from your involvement, suggestions and contributions. This platform is intended as a repository for extensions to the program based on your code contributions as well as for flagging and tracking open issues. Please use the **Issues** tab to report bugs and request features.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the repository layout, how to set up a development environment, how to add a new node type, and the pull-request and release process.

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -1,0 +1,106 @@
+Concepts and Architecture
+=========================
+
+This page explains how Thalamus is put together: the node pipeline, the data model
+that flows through it, the capture-file format, and the tooling that turns
+recordings into analysis-ready data.  It complements the :doc:`quickstart` (which
+walks through using the program) and the :doc:`Node Reference <nodes/index>` (which
+documents each node type).
+
+The node pipeline
+-----------------
+
+A Thalamus session is a **pipeline of nodes**.  Each node is a small, independently
+configurable unit, and every node plays one of four roles:
+
+* **Generators** produce data -- hardware acquisition (NIDAQ, INTAN, SPIKEGLX,
+  GENICAM, ...) or software sources (WAVE, WALLCLOCK, PUPIL).
+* **Consumers** terminate data -- recording it (STORAGE2), logging it (LOG), or
+  driving an output device (NIDAQ_OUT, OPHANIM).
+* **Transformers** consume data and produce new data -- analysis and mapping
+  (OCULOMATIC, ALGEBRA, LUA, NORMALIZE, ARUCO, ...).
+* **Controllers** coordinate the pipeline -- starting and stopping groups of nodes
+  (RUNNER, RUNNER2, TASK_CONTROLLER).
+
+You build an experiment by adding nodes, setting each node's type and properties,
+and **subscribing** consumers/transformers to the producers whose data they need.
+Most nodes have a small set of inline properties; nodes with richer configuration
+also provide a *node widget* that appears when the node is selected.  See the
+:doc:`Node Catalog <nodes/catalog>` for the full list of types.
+
+Because nodes are decoupled and communicate over gRPC, a pipeline can also span
+machines: a :doc:`REMOTE <nodes/remote>` node proxies another instance's stream, and
+a :doc:`RUNNER2 <nodes/runner2>` node can start/stop nodes on remote instances.
+
+The data model
+--------------
+
+All data is carried in a single message type, ``StorageRecord``.  Every record has a
+``node`` (the producing node's name), a ``time`` (see below), and exactly one *body*
+that determines the kind of data:
+
+* **analog** -- time-series samples.  An ``AnalogResponse`` holds a flat ``data``
+  array, a list of ``spans`` that name each channel and mark its slice of ``data``
+  (``begin``/``end``), and a ``sample_intervals`` array giving each channel's sample
+  period in nanoseconds.  (Integer-valued streams use ``int_data`` / ``ulong_data``.)
+* **image** -- a video/camera frame, with raw bytes, ``width``, ``height``,
+  pixel ``format`` (e.g. ``Gray``, ``RGB``, ``MPEG4``), and ``frame_interval``.
+* **text** -- a string message (log lines, event markers).
+* **xsens** -- motion-capture pose data: body segments with position and quaternion
+  rotation.
+* **metadata** -- key/value pairs (string, integer, or decimal).
+* **compressed** -- a compressed payload wrapping one of the above (used when analog
+  or video compression is enabled).
+
+This uniform model is why the same tools work across modalities, and why a single
+recording can interleave signals, video, markers, and motion on one timeline.
+
+Time
+----
+
+Record timestamps are expressed in **nanoseconds from a steady clock**, not a Unix
+epoch.  The clock is monotonic relative to an arbitrary start point, which makes it
+ideal for measuring intervals and latencies but means timestamps are not wall-clock
+dates.  To anchor a recording to absolute time, include a :doc:`WALLCLOCK
+<nodes/wallclock>` node.  For an analog record, the ``time`` marks the moment of the
+record's last sample, so the time of every sample can be reconstructed from the
+sample interval.
+
+The capture-file format
+-----------------------
+
+A recording is a ``.tha`` capture file: a flat sequence of records, each written as
+an 8-byte big-endian length prefix followed by the serialized ``StorageRecord``
+protobuf.  A STORAGE2 node writes one record every time a node it is subscribed to
+produces data, so the file is an interleaved, append-only log.
+
+By convention the first record carries a ``metadata`` body with the recording
+number (the ``Rec`` key), and a companion ``<file>.YYYYMMDD.R.json`` snapshot of the
+configuration is written alongside the capture.  See the :doc:`quickstart` for an
+annotated example of the records in a file.
+
+Reading and converting recordings
+----------------------------------
+
+Several bundled modules turn a ``.tha`` file into analysis-ready data:
+
+* ``python -m thalamus.record_reader2 FILE`` -- iterate over and print raw records.
+  In Python, ``thalamus.record_reader2.SimpleRecordReader`` yields ``StorageRecord``
+  messages (use it as a context manager).
+* ``python -m thalamus.dataframe -n NODE -i FILE`` -- export one node's analog (or
+  text) channels to CSV, Parquet, and other tabular formats.
+* ``python -m thalamus.hydrate FILE`` -- convert an entire capture into a single
+  HDF5 file.  For each analog channel it writes a ``data`` dataset of samples and a
+  ``received`` dataset of per-record timing, from which exact sample times can be
+  reconstructed.
+
+The :doc:`examples/index` page shows each of these end to end, and the
+``examples/`` folder in the repository contains runnable scripts.
+
+Persistence
+-----------
+
+Node configurations and window layouts can be saved and reloaded, so an experiment's
+full setup is reproducible.  When a node's configuration must change in a
+backward-incompatible way, a new numbered node type is introduced (for example
+STORAGE → STORAGE2) so existing setups keep working.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,11 +18,11 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Thalamus'
-copyright = '2024, Jarl Haggerty'
+copyright = '2024-2026, Jarl Haggerty'
 author = 'Jarl Haggerty'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3'
+release = '1.0.15'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -132,3 +132,120 @@ From here you can apply any analysis you like (NumPy, SciPy, pandas, MATLAB).  F
 worked analyses on real recordings -- including the figures from our paper -- see
 the `SimpleUseCase <https://github.com/cajigaslab/Thalamus/tree/main/SimpleUseCase>`_
 folder.
+
+Record event markers (text)
+---------------------------
+
+Experiments often interleave a continuous signal with discrete *event markers*
+such as ``trial_start`` or ``reward``.  Thalamus stores these as ``text`` records on
+the same timeline as the analog data.  ``examples/event_markers.py`` writes a
+recording with five markers on an ``events`` node plus a continuous ``reward``
+analog channel on a ``daq`` node:
+
+.. code-block::
+
+   python examples/event_markers.py -o events.tha
+
+Export the markers to a table with the ``text`` data type:
+
+.. code-block::
+
+   python -m thalamus.dataframe -n events -t text -i events.tha -f csv
+
+::
+
+   counter,text
+   200000000,trial_start
+   400000000,cue_on
+   600000000,cue_off
+   800000000,reward
+   1000000000,trial_end
+
+Record a synthetic video stream (images)
+----------------------------------------
+
+Camera data is stored as ``image`` records, each carrying the raw frame bytes plus
+width, height, pixel format, and frame interval.  ``examples/synthetic_video.py``
+writes a short ``Gray`` clip (no camera required) and extracts one frame to a PNG so
+you can see how to decode image records:
+
+.. code-block::
+
+   python examples/synthetic_video.py -o video.tha --frame 15 --png frame.png
+
+The key decode step is reshaping the raw bytes into a 2-D array:
+
+.. code-block:: python
+
+   import numpy
+   from thalamus.record_reader2 import SimpleRecordReader
+
+   with SimpleRecordReader("video.tha") as reader:
+       frames = [r for r in reader if r.WhichOneof("body") == "image"]
+   image = frames[15].image
+   arr = numpy.frombuffer(image.data[0], dtype=numpy.uint8).reshape(image.height, image.width)
+
+Record several nodes at once
+----------------------------
+
+A real session records many nodes into one file -- each tagged with its node name.
+``examples/multinode_recording.py`` writes an ``eye`` node (channels ``x`` and ``y``)
+and an ``emg`` node (channel ``ch0``):
+
+.. code-block::
+
+   python examples/multinode_recording.py -o session.tha
+
+Export each node independently by name:
+
+.. code-block::
+
+   python -m thalamus.dataframe -n eye -i session.tha -f csv -o eye.csv
+   python -m thalamus.dataframe -n emg -i session.tha -f csv -o emg.csv
+
+Summarize any capture file
+--------------------------
+
+When you receive an unfamiliar recording, ``examples/capture_summary.py`` reports
+its nodes, data types, analog channels, duration, and metadata:
+
+.. code-block::
+
+   python examples/capture_summary.py session.tha
+
+::
+
+   File: session.tha
+   Records: 627  {'metadata': 1, 'analog': 626}
+   Duration: 4.984 s
+   Metadata: [('Rec', 1)]
+   Nodes:
+     emg: {'analog': 313}  channels=['ch0']
+     eye: {'analog': 313}  channels=['x', 'y']
+     storage: {'metadata': 1}
+
+Measure closed-loop latency
+---------------------------
+
+Quantifying the latency of a closed loop -- a trigger fires and a downstream system
+responds some milliseconds later -- is a core Thalamus use case.
+``examples/closed_loop_latency.py`` synthesizes a recording with a ``trigger`` and a
+``response`` channel offset by a known delay, then recovers that delay by detecting
+and pairing rising edges (the same analysis behind the closed-loop performance
+figures in the paper):
+
+.. code-block::
+
+   python examples/closed_loop_latency.py
+
+::
+
+   Synthesized .../loop.tha (response lags trigger by 5 ms)
+   trigger edges: 5, response edges: 5
+   latency (ms): mean=5.000 std=0.000 min=5.000 max=5.000
+
+Pass a path to analyze your own recording instead:
+
+.. code-block::
+
+   python examples/closed_loop_latency.py recording.tha -n daq --trigger trigger --response response

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -1,0 +1,134 @@
+Examples
+========
+
+These examples are runnable end to end and require **no acquisition hardware**.
+They mirror the scripts in the `examples/ <https://github.com/cajigaslab/Thalamus/tree/main/examples>`_
+folder of the repository, so you can copy-paste from here or run the scripts
+directly.
+
+If you use Thalamus in your work, please cite our paper:
+`Thalamus: a real-time, closed-loop platform for synchronized multimodal data
+acquisition <https://www.nature.com/articles/s44172-026-00646-z>`_
+(Communications Engineering, Nature).
+
+.. contents::
+   :local:
+
+Synthesize and analyze a recording without hardware
+----------------------------------------------------
+
+A Thalamus recording (a ``.tha`` capture file) is simply a sequence of
+length-prefixed protobuf ``StorageRecord`` messages: a leading ``metadata``
+record followed by ``analog`` (or ``image``, ``text``, ...) records.  Because the
+format is open, you can produce a perfectly valid recording programmatically and
+then exercise the full analysis toolchain against it.
+
+This example generates a 5-second recording with two channels -- a 2 Hz sine wave
+and a 1 Hz square pulse -- and then reads, exports, hydrates, and plots it.
+
+1. Generate a capture file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following script writes a file that is indistinguishable from one produced by
+a STORAGE2 node.  Each analog record carries 16 ms of data; channels are
+concatenated in ``data`` and a ``Span`` maps each slice to a named channel.
+
+.. code-block:: python
+
+   import math, datetime, pathlib
+   from thalamus.thalamus_pb2 import StorageRecord, AnalogResponse, Span, Metadata, Pair
+   from thalamus.record_writer import write_record
+
+   SAMPLE_RATE, POLL_MS, DURATION_S = 1000, 16, 5
+   INTERVAL_NS = int(1e9 / SAMPLE_RATE)
+   SAMPLES_PER_POLL = SAMPLE_RATE * POLL_MS // 1000
+   total = SAMPLE_RATE * DURATION_S
+
+   out = pathlib.Path(f"synthetic.tha.{datetime.date.today():%Y%m%d}.1")
+   with out.open("wb") as stream:
+       write_record(stream, StorageRecord(
+           node="storage", time=0,
+           metadata=Metadata(keyvalues=[Pair(key="Rec", integral=1)])))
+       produced, t_ns = 0, 0
+       while produced < total:
+           count = min(SAMPLES_PER_POLL, total - produced)
+           sine, pulse = [], []
+           for i in range(count):
+               t = (produced + i) / SAMPLE_RATE
+               sine.append(math.sin(2 * math.pi * 2.0 * t))
+               pulse.append(5.0 if int(t * 2) % 2 == 0 else 0.0)
+           produced += count
+           t_ns += count * INTERVAL_NS
+           write_record(stream, StorageRecord(
+               node="wave", time=t_ns,
+               analog=AnalogResponse(
+                   data=sine + pulse,
+                   spans=[Span(begin=0, end=count, name="sine"),
+                          Span(begin=count, end=2 * count, name="pulse")],
+                   sample_intervals=[INTERVAL_NS, INTERVAL_NS], time=t_ns)))
+   print("wrote", out)
+
+The full script is available as ``examples/synthetic_recording.py``:
+
+.. code-block::
+
+   python examples/synthetic_recording.py -o demo.tha
+
+2. Inspect the records
+^^^^^^^^^^^^^^^^^^^^^^^
+
+You can iterate over the records directly with ``thalamus.record_reader2``:
+
+.. code-block::
+
+   python -m thalamus.record_reader2 demo.tha
+
+3. Export to CSV or Parquet
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``thalamus.dataframe`` module turns a node's channels into a tabular file:
+
+.. code-block::
+
+   python -m thalamus.dataframe -n wave -i demo.tha -f csv -o demo.csv
+
+The output is indexed by ``counter`` (the sample timestamp in nanoseconds) with one
+column per channel::
+
+   counter,sine,pulse
+   1000000,0.0,5.0
+   2000000,0.012566039883352607,5.0
+   ...
+
+4. Hydrate to HDF5
+^^^^^^^^^^^^^^^^^^
+
+To produce a single self-describing HDF5 file for downstream analysis, hydrate the
+capture:
+
+.. code-block::
+
+   python -m thalamus.hydrate demo.tha
+
+This writes ``demo.tha.h5`` containing, for each channel, a ``data`` dataset of
+samples and a ``received`` dataset of timing information (see :doc:`../quickstart`
+for the layout).
+
+5. Plot the channels
+^^^^^^^^^^^^^^^^^^^^^
+
+The ``examples/analyze_recording.py`` script reconstructs the per-channel time
+series straight from the ``.tha`` file and saves a plot:
+
+.. code-block::
+
+   python examples/analyze_recording.py demo.tha -n wave -o analysis.png
+
+.. image:: synthetic_analysis.png
+   :width: 100%
+   :alt: Sine and square-pulse channels from the synthetic recording
+
+From here you can apply any analysis you like (NumPy, SciPy, pandas, MATLAB).  For
+worked analyses on real recordings -- including the figures from our paper -- see
+the `SimpleUseCase <https://github.com/cajigaslab/Thalamus/tree/main/SimpleUseCase>`_
+folder.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Welcome to Thalamus's documentation!
    :caption: Contents:
 
    quickstart
+   examples/index
    nodes/index
 
 Indices and tables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Welcome to Thalamus's documentation!
    :caption: Contents:
 
    quickstart
+   concepts
    examples/index
    nodes/index
 

--- a/docs/source/nodes/algebra.rst
+++ b/docs/source/nodes/algebra.rst
@@ -1,0 +1,24 @@
+ALGEBRA
+=======
+
+The ALGEBRA node is a transformer that evaluates a user-supplied algebraic
+expression on each incoming sample.  It is a quick way to scale, offset, or
+otherwise process a signal without writing code.
+
+Usage
+-----
+
+Set the node's **Source** to the node whose data you want to transform, then enter
+an expression in the **Equation** field.  The variable ``X`` refers to the incoming
+sample value; for example, ``X*2 + 5`` doubles the signal and adds an offset of 5.
+
+Properties
+----------
+
+* **Source**: The node supplying the input samples.
+* **Equation**: The expression evaluated per sample.  Use ``X`` for the input value.
+* **Parser Error**: A read-only indicator.  When the equation cannot be parsed the
+  equation text turns red so you can correct it.
+
+For more complex, stateful processing (where a value depends on previous samples),
+use the ``LUA`` node instead.

--- a/docs/source/nodes/algebra.rst
+++ b/docs/source/nodes/algebra.rst
@@ -1,5 +1,8 @@
 ALGEBRA
 =======
+|ui|
+
+.. |ui| image:: algebra_ui.png
 
 The ALGEBRA node is a transformer that evaluates a user-supplied algebraic
 expression on each incoming sample.  It is a quick way to scale, offset, or

--- a/docs/source/nodes/analog.rst
+++ b/docs/source/nodes/analog.rst
@@ -1,0 +1,17 @@
+ANALOG
+======
+
+The ANALOG node is a flexible analog transformer.  In its default mode it passes an
+analog stream through, but it can also act as a **touchpad**: when configured as a
+touchpad it injects synthetic analog samples derived from the mouse position over
+its widget, which is handy for testing downstream nodes without real hardware.
+
+Properties
+----------
+
+* **Widget is Touchpad**: When enabled, the node's widget becomes a touchpad and the
+  mouse position is injected as analog data.  When disabled the node behaves as a
+  plain analog pass-through.
+
+Related nodes: see :doc:`toggle` for thresholding an analog signal into a binary
+state, and :doc:`algebra` / :doc:`lua` for arithmetic transforms.

--- a/docs/source/nodes/aruco.rst
+++ b/docs/source/nodes/aruco.rst
@@ -1,0 +1,26 @@
+ARUCO
+=====
+
+The ARUCO node detects ArUco / AprilTag fiducial markers in an image stream and
+outputs the pose (position and rotation) of each configured marker board.  It is a
+transformer: it consumes images from a camera node (e.g. GENICAM) and produces
+pose data.
+
+Usage
+-----
+
+Set the node's source to the camera node to analyze, then configure the marker
+dictionary and one or more boards.
+
+Properties
+----------
+
+* **Dictionary**: The ArUco marker dictionary the markers were generated from (for
+  example a 6x6 dictionary).  This must match the printed markers.
+* **Boards**: A list of marker boards to detect.  Each board describes its layout
+  (rows, columns, marker size and separation), the marker ids it contains, and an
+  optional position/orientation offset so the reported pose is expressed in your
+  chosen coordinate frame.
+
+Accurate poses require a calibrated camera; use the DISTORTION node to rectify the
+image stream first if your camera has significant lens distortion.

--- a/docs/source/nodes/aruco.rst
+++ b/docs/source/nodes/aruco.rst
@@ -1,5 +1,8 @@
 ARUCO
 =====
+|ui|
+
+.. |ui| image:: aruco_ui.png
 
 The ARUCO node detects ArUco / AprilTag fiducial markers in an image stream and
 outputs the pose (position and rotation) of each configured marker board.  It is a

--- a/docs/source/nodes/brainproducts.rst
+++ b/docs/source/nodes/brainproducts.rst
@@ -1,0 +1,20 @@
+BRAINPRODUCTS
+=============
+
+The BRAINPRODUCTS node streams EEG/biosignal data from a Brain Products amplifier
+through the BrainVision Amplifier SDK and republishes it as an analog stream.  It is
+a generator.
+
+The amplifier is detected and its channels, sample rate, and resolution are read
+from the device through the SDK, so there are no manual channel-configuration
+fields.
+
+Properties
+----------
+
+* **Running**: Connect to the amplifier and begin acquisition.
+
+.. note::
+
+   This node depends on the proprietary BrainVision Amplifier SDK library being
+   present; it is only available where that SDK can be loaded.

--- a/docs/source/nodes/catalog.rst
+++ b/docs/source/nodes/catalog.rst
@@ -30,19 +30,19 @@ Generators
    * - ``WALLCLOCK``
      - Emits the current time (system clock, NTP, or PTP) as a time series for synchronization.
    * - ``INTAN``
-     - Streams neural recordings from an Intan RHX acquisition system over TCP.
+     - Streams neural recordings from an Intan RHX acquisition system over TCP.  See :doc:`intan`.
    * - ``SPIKEGLX``
-     - Streams high-density electrophysiology data from a SpikeGLX / Neuropixels system.
+     - Streams high-density electrophysiology data from a SpikeGLX / Neuropixels system.  See :doc:`spikeglx`.
    * - ``BRAINPRODUCTS``
      - Streams EEG/biosignal data from Brain Products amplifiers.
    * - ``DELSYS``
-     - Streams wireless EMG data from Delsys sensors.
+     - Streams wireless EMG data from Delsys sensors.  See :doc:`delsys`.
    * - ``GENICAM``
-     - Acquires image streams from GenICam/GenTL-compliant cameras.
+     - Acquires image streams from GenICam/GenTL-compliant cameras.  See :doc:`genicam`.
    * - ``VIDEO`` / ``FFMPEG``
      - Decodes video/image streams from files or capture devices via FFmpeg.
    * - ``XSENS`` / ``MOCAP``
-     - Streams motion-capture pose data (segment positions and quaternion rotations).
+     - Streams motion-capture pose data (segment positions and quaternion rotations).  See :doc:`xsens`.
    * - ``HAND_ENGINE``
      - Streams hand/finger pose data from StretchSense Hand Engine.
    * - ``PUPIL``
@@ -92,7 +92,7 @@ Transformers
    * - ``ALGEBRA``
      - Evaluates a user-supplied algebraic expression on incoming samples.  See :doc:`algebra`.
    * - ``LUA``
-     - Evaluates Lua expressions on incoming samples, with state preserved across samples.
+     - Evaluates Lua expressions on incoming samples, with state preserved across samples.  See :doc:`lua`.
    * - ``NORMALIZE``
      - Linearly rescales an input range to a configured output range, with calibration caching.  See :doc:`normalize`.
    * - ``ANALOG``
@@ -100,15 +100,15 @@ Transformers
    * - ``TOGGLE``
      - Emits a binary 0/1 state based on a threshold.
    * - ``CHANNEL_PICKER``
-     - Selects, reorders, and renames channels from upstream sources.
+     - Selects and reorders channels from one or more upstream sources.  See :doc:`channel_picker`.
    * - ``FREQUENCY``
      - Monitors a channel's frequency and flags drift outside configured margins.
    * - ``SYNC``
-     - Cross-correlates paired channels from different nodes to measure timing alignment.
+     - Cross-correlates paired channels from different nodes to measure timing alignment.  See :doc:`sync`.
    * - ``OCULOMATIC``
      - Detects gaze position from an eye-camera video stream and outputs scaled analog coordinates.  See :doc:`oculomatic`.
    * - ``ARUCO``
-     - Detects ArUco/AprilTag fiducial markers in images and outputs board poses.
+     - Detects ArUco/AprilTag fiducial markers in images and outputs board poses.  See :doc:`aruco`.
    * - ``CHESSBOARD``
      - Detects chessboard corners in images for camera calibration / pose estimation.
    * - ``DISTORTION``

--- a/docs/source/nodes/catalog.rst
+++ b/docs/source/nodes/catalog.rst
@@ -34,25 +34,25 @@ Generators
    * - ``SPIKEGLX``
      - Streams high-density electrophysiology data from a SpikeGLX / Neuropixels system.  See :doc:`spikeglx`.
    * - ``BRAINPRODUCTS``
-     - Streams EEG/biosignal data from Brain Products amplifiers.
+     - Streams EEG/biosignal data from Brain Products amplifiers.  See :doc:`brainproducts`.
    * - ``DELSYS``
      - Streams wireless EMG data from Delsys sensors.  See :doc:`delsys`.
    * - ``GENICAM``
      - Acquires image streams from GenICam/GenTL-compliant cameras.  See :doc:`genicam`.
    * - ``VIDEO`` / ``FFMPEG``
-     - Decodes video/image streams from files or capture devices via FFmpeg.
+     - Decodes video/image streams from files or capture devices via FFmpeg.  See :doc:`video` / :doc:`ffmpeg`.
    * - ``XSENS`` / ``MOCAP``
      - Streams motion-capture pose data (segment positions and quaternion rotations).  See :doc:`xsens`.
    * - ``HAND_ENGINE``
-     - Streams hand/finger pose data from StretchSense Hand Engine.
+     - Streams hand/finger pose data from StretchSense Hand Engine.  See :doc:`hand_engine`.
    * - ``PUPIL``
      - Generates a synthetic eye image with a moving pupil (optionally random saccades) for testing eye-tracking pipelines.  See :doc:`pupil`.
    * - ``CHESSBOARD``
      - Renders a chessboard calibration-target image (for displaying a known pattern, e.g. for camera/display calibration).  See :doc:`chessboard`.
    * - ``REMOTE``
-     - Proxies a data stream from another Thalamus instance over gRPC.
+     - Proxies a data stream from another Thalamus instance over gRPC.  See :doc:`remote`.
    * - ``SAMPLE_MONITOR``
-     - Reports sample counts and timing statistics from upstream nodes (diagnostic).
+     - Monitors node sample rates and alerts when they drift from expectation (diagnostic).  See :doc:`sample_monitor`.
 
 Consumers
 ---------
@@ -66,15 +66,15 @@ Consumers
    * - ``STORAGE2``
      - Primary node for recording data to a ``.tha`` capture file, with per-modality selection, file copying, and metadata.  See :doc:`storage2`.
    * - ``STORAGE``
-     - Earlier-generation storage node (retained for backward compatibility).
+     - Earlier-generation storage node (retained for backward compatibility).  See :doc:`storage`.
    * - ``NIDAQ_OUT (NIDAQMX)``
      - Writes analog signals from Thalamus out to a National Instruments DAQ.  See :doc:`nidaq_out`.
    * - ``LOG``
-     - Receives and displays text log messages.
+     - Receives and displays text log messages.  See :doc:`log`.
    * - ``REMOTE_LOG``
-     - Aggregates log messages from a remote Thalamus instance.
+     - Aggregates log messages from a remote Thalamus instance.  See :doc:`remote_log`.
    * - ``STIM_PRINTER``
-     - Logs JSON-formatted electrical stimulation declarations.
+     - Logs JSON-formatted electrical stimulation declarations.  See :doc:`stim_printer`.
    * - ``TOUCH_SCREEN``
      - Maps raw touch-screen coordinates to calibrated screen coordinates.  See :doc:`touch_screen`.
    * - ``OPHANIM``
@@ -116,7 +116,7 @@ Transformers
    * - ``HEXASCOPE``
      - Servos a motorized mirror platform to track a target from a motion-capture source.  See :doc:`hexascope`.
    * - ``CECI``
-     - Generates multi-channel biphasic electrical stimulation with MUX/digital control.
+     - Generates multi-channel biphasic electrical stimulation with MUX/digital control.  See :doc:`ceci`.
    * - ``ROS2``
      - Bridges Thalamus data (images, gaze, transforms) to/from ROS 2 topics and TF2.  See :doc:`ros2`.
 
@@ -132,10 +132,10 @@ Controllers and Utilities
    * - ``RUNNER2``
      - Propagates its Running state to a configured list of (possibly remote) nodes so multiple nodes start/stop together.  See :doc:`runner2`.
    * - ``RUNNER``
-     - Simpler controller that mirrors its Running state to a list of local node names.
+     - Simpler controller that mirrors its Running state to a list of local node names.  See :doc:`runner`.
    * - ``NONE``
      - The default empty node; does nothing until you choose a type.
    * - ``THREAD_POOL``
-     - Exposes the shared worker thread pool (system/diagnostic).
+     - Exposes the shared worker thread pool (system/diagnostic).  See :doc:`thread_pool`.
    * - ``LOOP_TEST`` / ``TEST_PULSE_NODE``
-     - Diagnostic nodes that generate test signals for verifying signal routing and latency.
+     - Diagnostic nodes that generate test signals for verifying signal routing and latency.  See :doc:`loop_test` / :doc:`test_pulse`.

--- a/docs/source/nodes/catalog.rst
+++ b/docs/source/nodes/catalog.rst
@@ -28,7 +28,7 @@ Generators
    * - ``NIDAQ (NIDAQMX)``
      - Reads analog signals from a National Instruments DAQ.  See :doc:`nidaq`.
    * - ``WALLCLOCK``
-     - Emits the current time (system clock, NTP, or PTP) as a time series for synchronization.
+     - Emits the current time (system clock, NTP, or PTP) as a time series for synchronization.  See :doc:`wallclock`.
    * - ``INTAN``
      - Streams neural recordings from an Intan RHX acquisition system over TCP.  See :doc:`intan`.
    * - ``SPIKEGLX``
@@ -46,7 +46,7 @@ Generators
    * - ``HAND_ENGINE``
      - Streams hand/finger pose data from StretchSense Hand Engine.
    * - ``PUPIL``
-     - Detects pupil position and size from a video stream.
+     - Generates a synthetic eye image with a moving pupil (optionally random saccades) for testing eye-tracking pipelines.  See :doc:`pupil`.
    * - ``REMOTE``
      - Proxies a data stream from another Thalamus instance over gRPC.
    * - ``SAMPLE_MONITOR``
@@ -66,7 +66,7 @@ Consumers
    * - ``STORAGE``
      - Earlier-generation storage node (retained for backward compatibility).
    * - ``NIDAQ_OUT (NIDAQMX)``
-     - Writes analog signals from Thalamus out to a National Instruments DAQ.
+     - Writes analog signals from Thalamus out to a National Instruments DAQ.  See :doc:`nidaq_out`.
    * - ``LOG``
      - Receives and displays text log messages.
    * - ``REMOTE_LOG``
@@ -76,9 +76,9 @@ Consumers
    * - ``TOUCH_SCREEN``
      - Maps raw touch-screen coordinates to calibrated screen coordinates.  See :doc:`touch_screen`.
    * - ``OPHANIM``
-     - Drives a panoramic/sphere projection display over gRPC.
+     - Drives a panoramic/sphere projection display over gRPC.  See :doc:`ophanim`.
    * - ``TASK_CONTROLLER``
-     - Starts/stops an external behavioral task-controller service.
+     - Starts/stops an external behavioral task-controller service.  See :doc:`task_controller`.
 
 Transformers
 ------------
@@ -96,13 +96,13 @@ Transformers
    * - ``NORMALIZE``
      - Linearly rescales an input range to a configured output range, with calibration caching.  See :doc:`normalize`.
    * - ``ANALOG``
-     - Pass-through / touchpad analog node that can inject synthetic input from the mouse.
+     - Pass-through / touchpad analog node that can inject synthetic input from the mouse.  See :doc:`analog`.
    * - ``TOGGLE``
-     - Emits a binary 0/1 state based on a threshold.
+     - Emits a binary 0/1 state based on a threshold.  See :doc:`toggle`.
    * - ``CHANNEL_PICKER``
      - Selects and reorders channels from one or more upstream sources.  See :doc:`channel_picker`.
    * - ``FREQUENCY``
-     - Monitors a channel's frequency and flags drift outside configured margins.
+     - Monitors a channel's frequency and flags drift outside configured margins.  See :doc:`frequency`.
    * - ``SYNC``
      - Cross-correlates paired channels from different nodes to measure timing alignment.  See :doc:`sync`.
    * - ``OCULOMATIC``
@@ -110,15 +110,15 @@ Transformers
    * - ``ARUCO``
      - Detects ArUco/AprilTag fiducial markers in images and outputs board poses.  See :doc:`aruco`.
    * - ``CHESSBOARD``
-     - Detects chessboard corners in images for camera calibration / pose estimation.
+     - Detects chessboard corners in images for camera calibration / pose estimation.  See :doc:`chessboard`.
    * - ``DISTORTION``
-     - Applies camera-distortion correction to image streams.
+     - Applies camera-distortion correction to image streams.  See :doc:`distortion`.
    * - ``HEXASCOPE``
-     - Servos a motorized mirror platform to track a target from a motion-capture source.
+     - Servos a motorized mirror platform to track a target from a motion-capture source.  See :doc:`hexascope`.
    * - ``CECI``
      - Generates multi-channel biphasic electrical stimulation with MUX/digital control.
    * - ``ROS2``
-     - Bridges Thalamus data (images, gaze, transforms) to/from ROS 2 topics and TF2.
+     - Bridges Thalamus data (images, gaze, transforms) to/from ROS 2 topics and TF2.  See :doc:`ros2`.
 
 Controllers and Utilities
 --------------------------

--- a/docs/source/nodes/catalog.rst
+++ b/docs/source/nodes/catalog.rst
@@ -1,0 +1,141 @@
+Node Catalog
+============
+
+Thalamus ships with a large library of node types.  Every node falls into one of
+four roles:
+
+* **Generators** produce data (hardware acquisition, signal generation).
+* **Consumers** take data in and do something terminal with it (storage, logging, display).
+* **Transformers** consume data and produce new data (analysis, coordinate mapping, scripting).
+* **Controllers** coordinate the pipeline (starting/stopping groups of nodes).
+
+The tables below list the node types available in this release.  Select a node's
+type from the dropdown in its row in the node list to switch a node to that type.
+Nodes documented in detail have their own page linked from the
+:doc:`Nodes index <index>`.
+
+Generators
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Type
+     - Description
+   * - ``WAVE``
+     - Software signal generator (sine, square, triangle, random) with configurable frequency, amplitude, phase, offset and duty cycle.  See :doc:`wave`.
+   * - ``NIDAQ (NIDAQMX)``
+     - Reads analog signals from a National Instruments DAQ.  See :doc:`nidaq`.
+   * - ``WALLCLOCK``
+     - Emits the current time (system clock, NTP, or PTP) as a time series for synchronization.
+   * - ``INTAN``
+     - Streams neural recordings from an Intan RHX acquisition system over TCP.
+   * - ``SPIKEGLX``
+     - Streams high-density electrophysiology data from a SpikeGLX / Neuropixels system.
+   * - ``BRAINPRODUCTS``
+     - Streams EEG/biosignal data from Brain Products amplifiers.
+   * - ``DELSYS``
+     - Streams wireless EMG data from Delsys sensors.
+   * - ``GENICAM``
+     - Acquires image streams from GenICam/GenTL-compliant cameras.
+   * - ``VIDEO`` / ``FFMPEG``
+     - Decodes video/image streams from files or capture devices via FFmpeg.
+   * - ``XSENS`` / ``MOCAP``
+     - Streams motion-capture pose data (segment positions and quaternion rotations).
+   * - ``HAND_ENGINE``
+     - Streams hand/finger pose data from StretchSense Hand Engine.
+   * - ``PUPIL``
+     - Detects pupil position and size from a video stream.
+   * - ``REMOTE``
+     - Proxies a data stream from another Thalamus instance over gRPC.
+   * - ``SAMPLE_MONITOR``
+     - Reports sample counts and timing statistics from upstream nodes (diagnostic).
+
+Consumers
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Type
+     - Description
+   * - ``STORAGE2``
+     - Primary node for recording data to a ``.tha`` capture file, with per-modality selection, file copying, and metadata.  See :doc:`storage2`.
+   * - ``STORAGE``
+     - Earlier-generation storage node (retained for backward compatibility).
+   * - ``NIDAQ_OUT (NIDAQMX)``
+     - Writes analog signals from Thalamus out to a National Instruments DAQ.
+   * - ``LOG``
+     - Receives and displays text log messages.
+   * - ``REMOTE_LOG``
+     - Aggregates log messages from a remote Thalamus instance.
+   * - ``STIM_PRINTER``
+     - Logs JSON-formatted electrical stimulation declarations.
+   * - ``TOUCH_SCREEN``
+     - Maps raw touch-screen coordinates to calibrated screen coordinates.  See :doc:`touch_screen`.
+   * - ``OPHANIM``
+     - Drives a panoramic/sphere projection display over gRPC.
+   * - ``TASK_CONTROLLER``
+     - Starts/stops an external behavioral task-controller service.
+
+Transformers
+------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Type
+     - Description
+   * - ``ALGEBRA``
+     - Evaluates a user-supplied algebraic expression on incoming samples.  See :doc:`algebra`.
+   * - ``LUA``
+     - Evaluates Lua expressions on incoming samples, with state preserved across samples.
+   * - ``NORMALIZE``
+     - Linearly rescales an input range to a configured output range, with calibration caching.  See :doc:`normalize`.
+   * - ``ANALOG``
+     - Pass-through / touchpad analog node that can inject synthetic input from the mouse.
+   * - ``TOGGLE``
+     - Emits a binary 0/1 state based on a threshold.
+   * - ``CHANNEL_PICKER``
+     - Selects, reorders, and renames channels from upstream sources.
+   * - ``FREQUENCY``
+     - Monitors a channel's frequency and flags drift outside configured margins.
+   * - ``SYNC``
+     - Cross-correlates paired channels from different nodes to measure timing alignment.
+   * - ``OCULOMATIC``
+     - Detects gaze position from an eye-camera video stream and outputs scaled analog coordinates.  See :doc:`oculomatic`.
+   * - ``ARUCO``
+     - Detects ArUco/AprilTag fiducial markers in images and outputs board poses.
+   * - ``CHESSBOARD``
+     - Detects chessboard corners in images for camera calibration / pose estimation.
+   * - ``DISTORTION``
+     - Applies camera-distortion correction to image streams.
+   * - ``HEXASCOPE``
+     - Servos a motorized mirror platform to track a target from a motion-capture source.
+   * - ``CECI``
+     - Generates multi-channel biphasic electrical stimulation with MUX/digital control.
+   * - ``ROS2``
+     - Bridges Thalamus data (images, gaze, transforms) to/from ROS 2 topics and TF2.
+
+Controllers and Utilities
+--------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Type
+     - Description
+   * - ``RUNNER2``
+     - Propagates its Running state to a configured list of (possibly remote) nodes so multiple nodes start/stop together.  See :doc:`runner2`.
+   * - ``RUNNER``
+     - Simpler controller that mirrors its Running state to a list of local node names.
+   * - ``NONE``
+     - The default empty node; does nothing until you choose a type.
+   * - ``THREAD_POOL``
+     - Exposes the shared worker thread pool (system/diagnostic).
+   * - ``LOOP_TEST`` / ``TEST_PULSE_NODE``
+     - Diagnostic nodes that generate test signals for verifying signal routing and latency.

--- a/docs/source/nodes/catalog.rst
+++ b/docs/source/nodes/catalog.rst
@@ -47,6 +47,8 @@ Generators
      - Streams hand/finger pose data from StretchSense Hand Engine.
    * - ``PUPIL``
      - Generates a synthetic eye image with a moving pupil (optionally random saccades) for testing eye-tracking pipelines.  See :doc:`pupil`.
+   * - ``CHESSBOARD``
+     - Renders a chessboard calibration-target image (for displaying a known pattern, e.g. for camera/display calibration).  See :doc:`chessboard`.
    * - ``REMOTE``
      - Proxies a data stream from another Thalamus instance over gRPC.
    * - ``SAMPLE_MONITOR``
@@ -98,7 +100,7 @@ Transformers
    * - ``ANALOG``
      - Pass-through / touchpad analog node that can inject synthetic input from the mouse.  See :doc:`analog`.
    * - ``TOGGLE``
-     - Emits a binary 0/1 state based on a threshold.  See :doc:`toggle`.
+     - Flip-flop that toggles its output (0 / 3.3) on each rising threshold crossing of the input.  See :doc:`toggle`.
    * - ``CHANNEL_PICKER``
      - Selects and reorders channels from one or more upstream sources.  See :doc:`channel_picker`.
    * - ``FREQUENCY``
@@ -109,8 +111,6 @@ Transformers
      - Detects gaze position from an eye-camera video stream and outputs scaled analog coordinates.  See :doc:`oculomatic`.
    * - ``ARUCO``
      - Detects ArUco/AprilTag fiducial markers in images and outputs board poses.  See :doc:`aruco`.
-   * - ``CHESSBOARD``
-     - Detects chessboard corners in images for camera calibration / pose estimation.  See :doc:`chessboard`.
    * - ``DISTORTION``
      - Applies camera-distortion correction to image streams.  See :doc:`distortion`.
    * - ``HEXASCOPE``

--- a/docs/source/nodes/ceci.rst
+++ b/docs/source/nodes/ceci.rst
@@ -1,0 +1,18 @@
+CECI
+====
+
+The CECI node generates multi-channel biphasic electrical stimulation across one or
+two output devices, with channel multiplexing and digital control.  Stimulation
+parameters are declared through the stimulation interface; the node arms and
+delivers the requested pulse trains on the configured devices.
+
+Properties
+----------
+
+* **Device 0**: The name of the first output device used for stimulation.
+* **Device 1**: The name of the second output device (for configurations that span
+  two devices).
+
+Stimulation declarations (channels, amplitudes, pulse timing) are sent to the node
+through the stimulation API rather than as static configuration fields.  Use a
+:doc:`STIM_PRINTER <stim_printer>` node to log the declarations that are issued.

--- a/docs/source/nodes/channel_picker.rst
+++ b/docs/source/nodes/channel_picker.rst
@@ -1,0 +1,19 @@
+CHANNEL_PICKER
+==============
+
+The CHANNEL_PICKER node selects channels from one or more upstream nodes and
+re-publishes them as a single, reordered output stream.  It is a transformer: use
+it to pick out the channels you care about, combine channels from several sources,
+and assign them stable output positions.
+
+Usage
+-----
+
+Add the source nodes you want to pull from; the node tracks them under its
+**Sources** configuration.  For each selected channel you assign an **Out Channel**
+(its index/position in the output stream).  The node prevents two selected channels
+from being mapped to the same output position, automatically resolving conflicts to
+the next free index.
+
+The result is a clean, consistently ordered stream that downstream nodes (such as
+STORAGE2 or a data view) can subscribe to.

--- a/docs/source/nodes/channel_picker.rst
+++ b/docs/source/nodes/channel_picker.rst
@@ -1,5 +1,8 @@
 CHANNEL_PICKER
 ==============
+|ui|
+
+.. |ui| image:: channel_picker_ui.png
 
 The CHANNEL_PICKER node selects channels from one or more upstream nodes and
 re-publishes them as a single, reordered output stream.  It is a transformer: use
@@ -9,11 +12,15 @@ and assign them stable output positions.
 Usage
 -----
 
-Add the source nodes you want to pull from; the node tracks them under its
-**Sources** configuration.  For each selected channel you assign an **Out Channel**
-(its index/position in the output stream).  The node prevents two selected channels
-from being mapped to the same output position, automatically resolving conflicts to
-the next free index.
+Use the dropdown to choose a source node and **Add** the channels you want.  Each
+row in the table has three columns:
+
+* **Input**: The source channel being mapped.
+* **Channel**: The output channel index/position it is placed at.
+* **Name**: The name given to the output channel.
+
+The node prevents two selected channels from being mapped to the same output
+position, automatically resolving conflicts to the next free index.
 
 The result is a clean, consistently ordered stream that downstream nodes (such as
 STORAGE2 or a data view) can subscribe to.

--- a/docs/source/nodes/chessboard.rst
+++ b/docs/source/nodes/chessboard.rst
@@ -1,0 +1,18 @@
+CHESSBOARD
+==========
+
+The CHESSBOARD node detects the corners of a chessboard calibration target in an
+image stream.  It is a transformer used for camera calibration and pose estimation:
+the detected corner grid provides the correspondences needed to solve for a
+camera's geometry, and can also track the board's pose over time.
+
+Properties
+----------
+
+* **Source**: The camera node to analyze.
+* **Rows** / **Columns**: The number of internal corners along each dimension of the
+  chessboard.
+* **Running**: Begin detecting corners.
+
+For full lens-distortion correction built on chessboard detection, see the
+:doc:`distortion` node.

--- a/docs/source/nodes/chessboard.rst
+++ b/docs/source/nodes/chessboard.rst
@@ -1,18 +1,16 @@
 CHESSBOARD
 ==========
 
-The CHESSBOARD node detects the corners of a chessboard calibration target in an
-image stream.  It is a transformer used for camera calibration and pose estimation:
-the detected corner grid provides the correspondences needed to solve for a
-camera's geometry, and can also track the board's pose over time.
+The CHESSBOARD node is a generator that *renders* a chessboard pattern as an image
+stream.  It produces the calibration target itself (rather than detecting one),
+which is useful for displaying a known pattern on a screen or projector -- for
+example to calibrate a camera or a display with the :doc:`distortion` node.
 
 Properties
 ----------
 
-* **Source**: The camera node to analyze.
-* **Rows** / **Columns**: The number of internal corners along each dimension of the
-  chessboard.
-* **Running**: Begin detecting corners.
-
-For full lens-distortion correction built on chessboard detection, see the
-:doc:`distortion` node.
+* **Running**: Generate frames (the pattern is redrawn on a timer at roughly 60 Hz).
+* **Rows** / **Columns**: The number of squares drawn along each dimension of the
+  board.
+* **Height**: The height of the generated image; the square size and overall width
+  follow from the height and the row/column counts.

--- a/docs/source/nodes/delsys.rst
+++ b/docs/source/nodes/delsys.rst
@@ -1,0 +1,20 @@
+DELSYS
+======
+
+The DELSYS node streams data from Delsys wireless sensors (e.g. Trigno EMG and IMU
+sensors).  It is a generator: each enabled sensor component is republished as one
+or more analog channels.
+
+Usage
+-----
+
+When connected, the node scans the attached sensors and lists their **Components**.
+Each component row exposes:
+
+* **ID**: The sensor/component identifier.
+* **Selected**: Whether the component is acquired.
+* **Sample Mode**: The sensor's sampling mode (scan a component to populate the
+  available modes; different modes trade off channel count and sample rate).
+
+Select the components and sample modes you want and start the node to begin
+streaming.

--- a/docs/source/nodes/delsys.rst
+++ b/docs/source/nodes/delsys.rst
@@ -1,5 +1,8 @@
 DELSYS
 ======
+|ui|
+
+.. |ui| image:: delsys_ui.png
 
 The DELSYS node streams data from Delsys wireless sensors (e.g. Trigno EMG and IMU
 sensors).  It is a generator: each enabled sensor component is republished as one
@@ -8,10 +11,12 @@ or more analog channels.
 Usage
 -----
 
-When connected, the node scans the attached sensors and lists their **Components**.
-Each component row exposes:
+Use **Connect to Base** to connect to the Delsys base station, then **Scan** for and
+**Pair** sensors.  Discovered sensors are listed as **Components**, where each row
+exposes:
 
 * **ID**: The sensor/component identifier.
+* **Ready**: Whether the sensor is paired and ready.
 * **Selected**: Whether the component is acquired.
 * **Sample Mode**: The sensor's sampling mode (scan a component to populate the
   available modes; different modes trade off channel count and sample rate).

--- a/docs/source/nodes/distortion.rst
+++ b/docs/source/nodes/distortion.rst
@@ -1,5 +1,8 @@
 DISTORTION
 ==========
+|ui|
+
+.. |ui| image:: distortion_ui.png
 
 The DISTORTION node corrects camera lens distortion in an image stream.  It is a
 transformer: it consumes images from a camera node and republishes an undistorted

--- a/docs/source/nodes/distortion.rst
+++ b/docs/source/nodes/distortion.rst
@@ -1,0 +1,25 @@
+DISTORTION
+==========
+
+The DISTORTION node corrects camera lens distortion in an image stream.  It is a
+transformer: it consumes images from a camera node and republishes an undistorted
+image stream, which improves the accuracy of downstream pose estimation
+(:doc:`aruco`, :doc:`chessboard`).
+
+Calibration is performed by showing a chessboard to the camera and collecting
+detections; from these the node estimates the camera matrix and distortion
+coefficients used to rectify subsequent frames.
+
+Properties
+----------
+
+* **Rows** / **Columns**: The dimensions of the calibration chessboard.
+* **Threshold**: Detection threshold used when finding the chessboard.
+* **Show Threshold**: Display the thresholded image to aid setup.
+* **Invert**: Invert the image before detection (for dark-on-light vs light-on-dark
+  boards).
+* **Collecting**: When enabled, accumulate chessboard detections for calibration.
+* **Camera Matrix**: The 3×3 intrinsic camera matrix (estimated during calibration,
+  and reused once solved).
+* **Distortion Coefficients**: The lens distortion coefficients applied to rectify
+  the image.

--- a/docs/source/nodes/ffmpeg.rst
+++ b/docs/source/nodes/ffmpeg.rst
@@ -1,0 +1,23 @@
+FFMPEG
+======
+
+The FFMPEG node is a generator that ingests media through FFmpeg/libav and
+republishes it as an image stream.  Because it uses FFmpeg's input layer it can
+read a wide range of file formats as well as live capture devices (cameras,
+screen-grab inputs, etc.) by specifying an input format.
+
+Properties
+----------
+
+* **Input Name**: The input to open -- a file path or a device/URL understood by
+  FFmpeg.
+* **Input Format**: The FFmpeg input format/demuxer to use (for example a webcam or
+  screen-capture backend).  Leave unset to let FFmpeg infer it from the input.
+* **Options**: Additional FFmpeg input options (key/value pairs passed to the
+  demuxer/decoder).
+* **Target Framerate**: The desired output frame rate.
+* **Time Source**: How frame timestamps are assigned.
+* **Running**: Begin decoding.
+
+The node reports the **Actual Framerate** and throughput while running.  To replay a
+plain video file, the simpler :doc:`VIDEO <video>` node is usually sufficient.

--- a/docs/source/nodes/ffmpeg.rst
+++ b/docs/source/nodes/ffmpeg.rst
@@ -15,9 +15,9 @@ Properties
   screen-capture backend).  Leave unset to let FFmpeg infer it from the input.
 * **Options**: Additional FFmpeg input options (key/value pairs passed to the
   demuxer/decoder).
-* **Target Framerate**: The desired output frame rate.
 * **Time Source**: How frame timestamps are assigned.
 * **Running**: Begin decoding.
 
-The node reports the **Actual Framerate** and throughput while running.  To replay a
-plain video file, the simpler :doc:`VIDEO <video>` node is usually sufficient.
+The node reports the **Target Framerate** (derived from the input stream) and its
+throughput while running.  To replay a plain video file, the simpler
+:doc:`VIDEO <video>` node is usually sufficient.

--- a/docs/source/nodes/frequency.rst
+++ b/docs/source/nodes/frequency.rst
@@ -1,0 +1,18 @@
+FREQUENCY
+=========
+
+The FREQUENCY node monitors the rate of a channel and flags when it drifts outside
+expected bounds.  It is a watchdog for acquisition health: if a device starts
+dropping samples or running fast/slow, the node raises an alert.
+
+Properties
+----------
+
+* **Source**: The node to monitor.
+* **Channel Number**: Which channel of the source to measure.
+* **Expected Frequency**: The frequency the channel should run at.
+* **Expected Frequency Std**: The allowed variability (standard deviation) around the
+  expected frequency before an alert is raised.
+
+The node reports the measured **Mean** and **Std** of the frequency and sets an
+**Alert** when the channel is outside the expected parameters.

--- a/docs/source/nodes/genicam.rst
+++ b/docs/source/nodes/genicam.rst
@@ -1,0 +1,29 @@
+GENICAM
+=======
+
+The GENICAM node acquires image streams from cameras that implement the GenICam /
+GenTL standard (many machine-vision USB3, GigE, and CoaXPress cameras).  It is a
+generator: it produces an image stream that other nodes (STORAGE2, OCULOMATIC,
+ARUCO, DISTORTION, ...) can consume.
+
+The appropriate GenTL producer (``.cti``) for your camera vendor must be installed
+and discoverable for the camera to appear.
+
+Properties
+----------
+
+* **Camera**: The camera to open, selected from the cameras discovered on the system.
+* **Frame Rate**: Acquisition frame rate.
+* **Exposure**: Exposure time (the value is stored internally as ``ExposureTime`` in
+  microseconds).
+* **Region of interest**: ``OffsetX``, ``OffsetY``, ``Width``, and ``Height`` define the
+  acquired image region.  ``WidthMax`` / ``HeightMax`` reflect the sensor's maximum
+  dimensions.  The node widget lets you drag the ROI rectangle directly on the live
+  image.
+
+Advanced camera features
+------------------------
+
+Cameras expose additional GenICam feature nodes (gain, pixel format, trigger mode,
+etc.).  These are surfaced under **Camera Values**, allowing vendor-specific
+features to be inspected and set without a code change.

--- a/docs/source/nodes/genicam.rst
+++ b/docs/source/nodes/genicam.rst
@@ -1,5 +1,8 @@
 GENICAM
 =======
+|ui|
+
+.. |ui| image:: genicam_ui.png
 
 The GENICAM node acquires image streams from cameras that implement the GenICam /
 GenTL standard (many machine-vision USB3, GigE, and CoaXPress cameras).  It is a
@@ -16,6 +19,7 @@ Properties
 * **Frame Rate**: Acquisition frame rate.
 * **Exposure**: Exposure time (the value is stored internally as ``ExposureTime`` in
   microseconds).
+* **Gain**: Sensor gain.
 * **Region of interest**: ``OffsetX``, ``OffsetY``, ``Width``, and ``Height`` define the
   acquired image region.  ``WidthMax`` / ``HeightMax`` reflect the sensor's maximum
   dimensions.  The node widget lets you drag the ROI rectangle directly on the live

--- a/docs/source/nodes/hand_engine.rst
+++ b/docs/source/nodes/hand_engine.rst
@@ -13,8 +13,11 @@ Properties
   is ``9000``).
 * **Running**: Connect to Hand Engine and begin streaming.
 
-The node also exposes haptic-feedback controls used to drive the glove's actuators:
+In addition to the MOCAP segments, the node emits analog channels derived from the
+pose: a ``Pose Change`` channel and per-finger distance channels (``Thumb Distance
+(m)``, ``Index Distance (m)``, etc.).  Two parameters shape the emitted ``Pose
+Change`` signal:
 
-* **Num Props**: Number of feedback props/actuators.
-* **Amplitude**: Feedback amplitude.
-* **Duration (ms)**: Feedback duration in milliseconds.
+* **Amplitude**: The value emitted on the ``Pose Change`` channel when a pose change
+  occurs.
+* **Duration (ms)**: How long, in milliseconds, that emitted pose-change pulse lasts.

--- a/docs/source/nodes/hand_engine.rst
+++ b/docs/source/nodes/hand_engine.rst
@@ -1,0 +1,20 @@
+HAND_ENGINE
+===========
+
+The HAND_ENGINE node streams hand and finger pose data from StretchSense Hand
+Engine and republishes it as a motion-capture (MOCAP) stream of segments, each with
+a position and rotation.  It is a generator used to capture hand kinematics from a
+motion-capture glove.
+
+Properties
+----------
+
+* **Address**: The address of the Hand Engine stream (``host:port``; the default port
+  is ``9000``).
+* **Running**: Connect to Hand Engine and begin streaming.
+
+The node also exposes haptic-feedback controls used to drive the glove's actuators:
+
+* **Num Props**: Number of feedback props/actuators.
+* **Amplitude**: Feedback amplitude.
+* **Duration (ms)**: Feedback duration in milliseconds.

--- a/docs/source/nodes/hexascope.rst
+++ b/docs/source/nodes/hexascope.rst
@@ -1,5 +1,8 @@
 HEXASCOPE
 =========
+|ui|
+
+.. |ui| image:: hexascope_ui.png
 
 The HEXASCOPE node controls a motorized mirror platform that steers an optical path
 to follow a moving target.  It is a transformer that consumes motion-capture pose

--- a/docs/source/nodes/hexascope.rst
+++ b/docs/source/nodes/hexascope.rst
@@ -1,0 +1,20 @@
+HEXASCOPE
+=========
+
+The HEXASCOPE node controls a motorized mirror platform that steers an optical path
+to follow a moving target.  It is a transformer that consumes motion-capture pose
+data and drives the platform so that a chosen objective stays aimed at a chosen
+field point.
+
+Properties
+----------
+
+* **Motion Tracking Node**: The motion-capture (MOCAP) source that provides target
+  poses.
+* **Objective Pose**: The pose (from the source) that represents the objective being
+  aimed.
+* **Field Pose**: The pose that represents the field/target point to track.
+* **Running**: Engage tracking and begin moving the platform.
+
+Before tracking, the platform must be **homed**; the node reports its **Homing** /
+**Homed** status while it establishes a known reference position.

--- a/docs/source/nodes/index.rst
+++ b/docs/source/nodes/index.rst
@@ -23,7 +23,19 @@ detailed pages below for commonly used nodes.
    sync
    genicam
    aruco
+   chessboard
+   distortion
    intan
    spikeglx
    delsys
    xsens
+   pupil
+   wallclock
+   analog
+   toggle
+   frequency
+   nidaq_out
+   task_controller
+   ophanim
+   hexascope
+   ros2

--- a/docs/source/nodes/index.rst
+++ b/docs/source/nodes/index.rst
@@ -1,11 +1,20 @@
 Nodes
 =====
 
+Nodes are the building blocks of a Thalamus pipeline.  Start with the
+:doc:`catalog` for an overview of every available node type, then see the
+detailed pages below for commonly used nodes.
+
 .. toctree::
    :maxdepth: 2
    :caption: Nodes:
 
+   catalog
    wave
    storage2
    nidaq
-
+   oculomatic
+   touch_screen
+   runner2
+   algebra
+   normalize

--- a/docs/source/nodes/index.rst
+++ b/docs/source/nodes/index.rst
@@ -39,3 +39,18 @@ detailed pages below for commonly used nodes.
    ophanim
    hexascope
    ros2
+   video
+   ffmpeg
+   hand_engine
+   brainproducts
+   remote
+   remote_log
+   runner
+   sample_monitor
+   storage
+   log
+   stim_printer
+   ceci
+   thread_pool
+   loop_test
+   test_pulse

--- a/docs/source/nodes/index.rst
+++ b/docs/source/nodes/index.rst
@@ -18,3 +18,12 @@ detailed pages below for commonly used nodes.
    runner2
    algebra
    normalize
+   lua
+   channel_picker
+   sync
+   genicam
+   aruco
+   intan
+   spikeglx
+   delsys
+   xsens

--- a/docs/source/nodes/intan.rst
+++ b/docs/source/nodes/intan.rst
@@ -1,0 +1,21 @@
+INTAN
+=====
+
+The INTAN node streams electrophysiology data from an Intan RHX acquisition system
+(e.g. an RHD/RHS controller).  It is a generator: Thalamus connects to the RHX
+software over TCP and republishes the waveform data as an analog stream.
+
+In the RHX software, enable the TCP command and waveform servers so Thalamus can
+connect.
+
+Properties
+----------
+
+* **Address**: Host address of the machine running the Intan RHX software.
+* **Command Port**: TCP port of the RHX command server (used to query configuration
+  and start/stop streaming).
+* **Waveform Port**: TCP port of the RHX waveform server (the data stream).
+* **Channels**: The set of channels to acquire.
+* **Metadata Node**: Optional node whose metadata is associated with this stream.
+* **Running**: Connect and begin streaming.  The node reports the negotiated
+  ``SampleRateHertz`` and a **Connected** status once the link is established.

--- a/docs/source/nodes/log.rst
+++ b/docs/source/nodes/log.rst
@@ -1,0 +1,10 @@
+LOG
+===
+
+The LOG node receives text log messages and displays them in its widget.  It is a
+consumer that gives an experiment a place to collect human-readable notes and
+diagnostic messages on the same timeline as the data; when recorded, those messages
+are stored as ``text`` records.
+
+There are no configuration fields to set -- log text arrives from other nodes and
+clients through the logging API, and from the node's own widget.

--- a/docs/source/nodes/loop_test.rst
+++ b/docs/source/nodes/loop_test.rst
@@ -1,16 +1,16 @@
 LOOP_TEST
 =========
 
-The LOOP_TEST node is a diagnostic used to verify signal routing and measure
-round-trip latency through a loop.  It generates a sinusoidal test signal and can
-compare it against a returning signal, which is useful for validating that data
-flows correctly through a chain of nodes (or out to hardware and back).
+The LOOP_TEST node is a diagnostic signal generator.  It emits a sinusoidal test
+signal (a single ``Sin`` output channel) whose frequency is taken from an input
+value, which is useful for exercising and validating signal routing through a
+pipeline.
 
 Properties
 ----------
 
-* **Source**: The node carrying the returning signal to compare against.
-* **Channel**: The channel of the source to use.
+* **Source**: The node whose value sets the frequency of the generated sinusoid.
+* **Channel**: The channel of the source to read the frequency from.
 
-The generated test signal is a sinusoid (``Sin``) that the node emits and watches for
-on the source.
+The most recent value read from the selected source/channel is used as the
+frequency of the emitted ``Sin`` signal.

--- a/docs/source/nodes/loop_test.rst
+++ b/docs/source/nodes/loop_test.rst
@@ -1,0 +1,16 @@
+LOOP_TEST
+=========
+
+The LOOP_TEST node is a diagnostic used to verify signal routing and measure
+round-trip latency through a loop.  It generates a sinusoidal test signal and can
+compare it against a returning signal, which is useful for validating that data
+flows correctly through a chain of nodes (or out to hardware and back).
+
+Properties
+----------
+
+* **Source**: The node carrying the returning signal to compare against.
+* **Channel**: The channel of the source to use.
+
+The generated test signal is a sinusoid (``Sin``) that the node emits and watches for
+on the source.

--- a/docs/source/nodes/lua.rst
+++ b/docs/source/nodes/lua.rst
@@ -1,5 +1,8 @@
 LUA
 ===
+|ui|
+
+.. |ui| image:: lua_ui.png
 
 The LUA node is a scriptable transformer.  It evaluates Lua expressions on incoming
 data and emits the results as new channels.  Unlike the ALGEBRA node, Lua scripts

--- a/docs/source/nodes/lua.rst
+++ b/docs/source/nodes/lua.rst
@@ -1,0 +1,19 @@
+LUA
+===
+
+The LUA node is a scriptable transformer.  It evaluates Lua expressions on incoming
+data and emits the results as new channels.  Unlike the ALGEBRA node, Lua scripts
+can keep state between samples, enabling filters, counters, and other stateful
+processing.
+
+Usage
+-----
+
+The node widget holds a list of **Equations**.  Use the add/remove controls to
+manage them.  Each equation has:
+
+* **Name**: The name of the output channel produced by the equation.
+* **Equation**: The Lua expression to evaluate.  If it fails to parse or run, an
+  error is shown next to the equation so you can correct it.
+
+Each named equation becomes a channel in the node's output stream.

--- a/docs/source/nodes/nidaq_out.rst
+++ b/docs/source/nodes/nidaq_out.rst
@@ -1,0 +1,20 @@
+NIDAQ_OUT
+=========
+
+The ``NIDAQ_OUT (NIDAQMX)`` node is a consumer that writes an analog stream from
+Thalamus out to a National Instruments DAQ.  It is the counterpart to the
+:doc:`NIDAQ <nidaq>` input node and is commonly used to drive external hardware --
+for example writing computed gaze coordinates out as voltages, or generating
+stimulation waveforms.
+
+Properties
+----------
+
+* **Source**: The node whose data is written to the DAQ.
+* **Channel**: A list of DAQ output channels (and channel ranges) to write to.
+* **Channel Type**: Output as voltage or current.
+* **Sample Rate**: The output sample rate.
+* **Poll Interval**: How often, in milliseconds, data is pushed to the device.
+* **Running**: Begin writing to the DAQ.
+
+All input spans being written must share the same length and sample interval.

--- a/docs/source/nodes/nidaq_out.rst
+++ b/docs/source/nodes/nidaq_out.rst
@@ -12,9 +12,9 @@ Properties
 
 * **Source**: The node whose data is written to the DAQ.
 * **Channel**: A list of DAQ output channels (and channel ranges) to write to.
-* **Channel Type**: Output as voltage or current.
-* **Sample Rate**: The output sample rate.
-* **Poll Interval**: How often, in milliseconds, data is pushed to the device.
+* **Digital**: Write to digital output lines instead of analog output channels.
 * **Running**: Begin writing to the DAQ.
 
-All input spans being written must share the same length and sample interval.
+The output sample rate follows from the source node's data; the timing parameters
+(``Sample Rate``, ``Poll Interval``, ``Channel Type``) configured on the
+:doc:`NIDAQ <nidaq>` input node do not apply here.

--- a/docs/source/nodes/normalize.rst
+++ b/docs/source/nodes/normalize.rst
@@ -1,5 +1,8 @@
 NORMALIZE
 =========
+|ui|
+
+.. |ui| image:: normalize_ui.png
 
 The NORMALIZE node is a transformer that linearly rescales an input signal so that
 its observed range maps onto a configured output range.  It is useful for putting a

--- a/docs/source/nodes/normalize.rst
+++ b/docs/source/nodes/normalize.rst
@@ -1,0 +1,30 @@
+NORMALIZE
+=========
+
+The NORMALIZE node is a transformer that linearly rescales an input signal so that
+its observed range maps onto a configured output range.  It is useful for putting a
+raw sensor signal into normalized units (for example 0–1) before further
+processing or display.
+
+Usage
+-----
+
+Set the node's **Source** to the node to normalize and configure the desired output
+range with **Min Out** and **Max Out**.  As data flows through, the node tracks the
+minimum and maximum values it has seen and maps that observed range onto
+``[Min Out, Max Out]``.
+
+Properties
+----------
+
+* **Source**: The node supplying the input samples.
+* **Min** (Min Out): The output value the observed minimum maps to (default ``0``).
+* **Max** (Max Out): The output value the observed maximum maps to (default ``1``).
+
+Calibration controls
+---------------------
+
+* **Reset**: Clears the tracked input range so the node re-learns the minimum and
+  maximum from subsequent data.
+* **Cache**: Persists the current calibration so it is reused across runs instead of
+  being re-learned each time.

--- a/docs/source/nodes/oculomatic.rst
+++ b/docs/source/nodes/oculomatic.rst
@@ -1,5 +1,8 @@
 OCULOMATIC
 ==========
+|ui|
+
+.. |ui| image:: oculomatic_ui.png
 
 The OCULOMATIC node is an eye-tracking transformer.  It consumes an image stream
 (typically an eye camera) and produces an analog stream containing the detected

--- a/docs/source/nodes/oculomatic.rst
+++ b/docs/source/nodes/oculomatic.rst
@@ -1,0 +1,34 @@
+OCULOMATIC
+==========
+
+The OCULOMATIC node is an eye-tracking transformer.  It consumes an image stream
+(typically an eye camera) and produces an analog stream containing the detected
+gaze position.  The detection is a thresholded blob/pupil detector, and the
+output coordinates are scaled so they can be written directly to an analog output
+(e.g. a NIDAQ_OUT node feeding downstream hardware).
+
+Usage
+-----
+
+Select OCULOMATIC as the node type and choose the video node to analyze as the
+node's source.  The node widget shows the live image with the detected pupil
+annotated and exposes the following controls.
+
+Properties
+----------
+
+* **Computing**: Enable/disable pupil detection.  When off, the node passes the
+  image through without producing gaze coordinates.
+* **Threshold**: Brightness threshold (0–255) used to segment the pupil from the
+  background.
+* **Min Area**: Smallest blob area accepted as a pupil.  Rejects small specular
+  reflections and noise.
+* **Max Area**: Largest blob area accepted as a pupil.
+* **X Gain** / **Y Gain**: Scale factors applied to the detected pupil position to
+  convert pixel coordinates into the output (analog) coordinate space.
+* **Invert X** / **Invert Y**: Flip the sign of the X or Y output, used to match the
+  camera orientation to the expected coordinate convention.
+
+The annotated image is also republished, so a downstream STORAGE2 node can save
+the original eye image, the annotated image, or just the gaze time series as
+needed (see the STORAGE2 per-modality toggles).

--- a/docs/source/nodes/ophanim.rst
+++ b/docs/source/nodes/ophanim.rst
@@ -1,0 +1,12 @@
+OPHANIM
+=======
+
+The OPHANIM node drives an Ophanim panoramic / sphere projection display over gRPC.
+It is a consumer that forwards display commands to the projection service so visual
+stimuli can be presented in sync with the rest of the pipeline.
+
+Properties
+----------
+
+* **Address**: The gRPC address of the Ophanim display service.
+* **Running**: Connect to the display service and begin driving it.

--- a/docs/source/nodes/pupil.rst
+++ b/docs/source/nodes/pupil.rst
@@ -1,0 +1,15 @@
+PUPIL
+=====
+
+The PUPIL node is a generator that produces a **synthetic eye image** containing a
+moving pupil.  It is a test/simulation source: feed its image stream into an
+OCULOMATIC node to exercise an eye-tracking pipeline without a real eye camera.
+
+Properties
+----------
+
+* **Running**: Generate frames.
+* **Width** / **Height**: Dimensions of the generated image.
+* **Random Saccade**: When enabled, the simulated pupil jumps to a new random
+  position roughly once per second, imitating saccadic eye movements.  When
+  disabled the pupil holds still.

--- a/docs/source/nodes/remote.rst
+++ b/docs/source/nodes/remote.rst
@@ -1,0 +1,20 @@
+REMOTE
+======
+
+The REMOTE node proxies a data stream from another Thalamus instance over gRPC.  It
+lets a pipeline consume data produced on a different machine as if it were a local
+node, which is the basis for distributing acquisition and computation across
+several computers.
+
+Properties
+----------
+
+* **Address**: The address of the remote Thalamus instance to connect to.
+* **Node**: The name of the node on the remote instance whose data to stream.
+* **Probe Size** / **Probe Frequency**: Parameters of the periodic ping/probe the node
+  uses to measure the connection (latency and bandwidth).
+* **Running**: Connect and begin streaming.
+
+While connected the node reports a **Connected** status, the measured **Bytes Per
+Second**, and ping/latency information.  See :doc:`runner2` for starting and stopping
+remote nodes, and :doc:`remote_log` for the logging equivalent.

--- a/docs/source/nodes/remote_log.rst
+++ b/docs/source/nodes/remote_log.rst
@@ -1,0 +1,17 @@
+REMOTE_LOG
+==========
+
+The REMOTE_LOG node proxies the log stream from another Thalamus instance over
+gRPC, so log messages produced on a remote machine can be aggregated locally.  It
+is the logging counterpart to the :doc:`REMOTE <remote>` data node.
+
+Properties
+----------
+
+* **Address**: The address of the remote Thalamus instance to connect to.
+* **Probe Size** / **Probe Frequency**: Parameters of the periodic ping/probe used to
+  measure the connection.
+* **Running**: Connect and begin streaming the remote log.
+
+While connected the node reports a **Connected** status, the measured **Bytes Per
+Second**, and ping/latency information.

--- a/docs/source/nodes/ros2.rst
+++ b/docs/source/nodes/ros2.rst
@@ -1,0 +1,18 @@
+ROS2
+====
+
+The ROS2 node bridges Thalamus to a ROS 2 system.  It is a transformer that
+republishes data from Thalamus nodes onto ROS 2 topics (and TF2 frames), so that
+robots and other ROS 2 components can consume Thalamus data in real time.
+
+Usage
+-----
+
+Add the Thalamus nodes you want to bridge under the node's **Sources**.  For each
+source you configure the ROS 2 topics it should be published to:
+
+* **Image Topic**: Topic to publish the source's image stream on.
+* **Camera Info Topic**: Topic to publish the associated camera calibration info on.
+* **Gaze Topic**: Topic to publish gaze / coordinate data on.
+
+Leave a topic blank to skip publishing that stream for a given source.

--- a/docs/source/nodes/ros2.rst
+++ b/docs/source/nodes/ros2.rst
@@ -1,5 +1,8 @@
 ROS2
 ====
+|ui|
+
+.. |ui| image:: ros2_ui.png
 
 The ROS2 node bridges Thalamus to a ROS 2 system.  It is a transformer that
 republishes data from Thalamus nodes onto ROS 2 topics (and TF2 frames), so that

--- a/docs/source/nodes/runner.rst
+++ b/docs/source/nodes/runner.rst
@@ -1,0 +1,16 @@
+RUNNER
+======
+
+The RUNNER node is a simple controller that mirrors its Running state onto a list of
+other nodes in the local pipeline.  When you start or stop the RUNNER, every node it
+targets is started or stopped to match, so you can control a group of nodes with a
+single action.
+
+Properties
+----------
+
+* **Targets**: A comma-separated list of node names to control.
+* **Running**: When toggled, every node named in **Targets** is set to the same state.
+
+For controlling nodes on remote Thalamus instances (each with its own address), use
+the :doc:`RUNNER2 <runner2>` node instead.

--- a/docs/source/nodes/runner2.rst
+++ b/docs/source/nodes/runner2.rst
@@ -1,0 +1,29 @@
+RUNNER2
+=======
+
+The RUNNER2 node is a controller that lets you start and stop many nodes with a
+single action.  Whenever its **Running** state changes it propagates that state to
+every node in its target list.  Unlike the simpler RUNNER node, RUNNER2 can target
+nodes on remote Thalamus instances by specifying an address for each target.
+
+Usage
+-----
+
+Use the **Add** / **Remove** buttons in the node widget to manage the target list.
+Each target row has two fields:
+
+* **Name**: The name of the node to control.  Double-clicking this cell shows the
+  available node names.
+* **Address**: The address of the Thalamus instance that hosts the target node.
+  Leave blank to target a node in the local pipeline.
+
+Properties
+----------
+
+* **Running**: When toggled, every node in the target list is started or stopped to
+  match.  The widget's button is colored green (START) or red (STOP) to reflect the
+  current state.
+* **Targets**: The list of ``Name`` / ``Address`` pairs described above.
+
+This makes RUNNER2 the standard way to begin and end a recording across all of the
+acquisition nodes in an experiment at once.

--- a/docs/source/nodes/runner2.rst
+++ b/docs/source/nodes/runner2.rst
@@ -1,5 +1,8 @@
 RUNNER2
 =======
+|ui|
+
+.. |ui| image:: runner2_ui.png
 
 The RUNNER2 node is a controller that lets you start and stop many nodes with a
 single action.  Whenever its **Running** state changes it propagates that state to

--- a/docs/source/nodes/sample_monitor.rst
+++ b/docs/source/nodes/sample_monitor.rst
@@ -1,0 +1,18 @@
+SAMPLE_MONITOR
+==============
+
+The SAMPLE_MONITOR node is a diagnostic that watches the sample rate of other nodes
+and raises an alert when a node's rate falls outside expected parameters.  Use it to
+catch a device that has started dropping samples or stalled during a recording.
+
+Properties
+----------
+
+* **Nodes**: The list of nodes to monitor.  Each entry is identified by its **Name**.
+
+For each monitored node the SAMPLE_MONITOR reports the observed rate alongside the
+expected rate and sets an **Alert** when the sample rate is outside the expected
+parameters.
+
+For monitoring a single channel's frequency against a specific expected value, see
+the :doc:`FREQUENCY <frequency>` node.

--- a/docs/source/nodes/sample_monitor.rst
+++ b/docs/source/nodes/sample_monitor.rst
@@ -1,5 +1,8 @@
 SAMPLE_MONITOR
 ==============
+|ui|
+
+.. |ui| image:: sample_monitor_ui.png
 
 The SAMPLE_MONITOR node is a diagnostic that watches the sample rate of other nodes
 and raises an alert when a node's rate falls outside expected parameters.  Use it to

--- a/docs/source/nodes/spikeglx.rst
+++ b/docs/source/nodes/spikeglx.rst
@@ -1,0 +1,19 @@
+SPIKEGLX
+========
+
+The SPIKEGLX node streams high-density electrophysiology data from a SpikeGLX /
+Neuropixels acquisition system.  It is a generator: Thalamus connects to the
+SpikeGLX remote-command server and republishes the selected stream as analog data.
+
+Enable the SpikeGLX *Remote Command Server* so Thalamus can connect.
+
+Properties
+----------
+
+* **Address**: Host (and port) of the SpikeGLX remote-command server.
+* **Stream**: The stream/probe to acquire (SpikeGLX exposes IMEC probe streams; the
+  node queries the available probes and stream count when it connects).
+* **Metadata Node**: Optional node whose metadata is associated with this stream.
+* **Publish**: Whether to publish the acquired data into the pipeline.
+* **Running**: Connect and begin streaming.  The node reports a **Connected** status
+  and any connection **Error** once it attempts the link.

--- a/docs/source/nodes/stim_printer.rst
+++ b/docs/source/nodes/stim_printer.rst
@@ -1,0 +1,10 @@
+STIM_PRINTER
+============
+
+The STIM_PRINTER node receives electrical-stimulation declarations and logs them as
+JSON.  It is a consumer used to record and inspect the stimulation parameters that
+were requested during an experiment, providing an auditable trail of what was
+declared.
+
+There are no configuration fields to set -- stimulation declarations arrive through
+the stimulation interface and are printed/logged by the node.

--- a/docs/source/nodes/storage.rst
+++ b/docs/source/nodes/storage.rst
@@ -1,5 +1,8 @@
 STORAGE
 =======
+|ui|
+
+.. |ui| image:: storage_ui.png
 
 STORAGE is the earlier-generation recording node.  It saves data from a set of
 source nodes to a ``.tha`` capture file.  New experiments should prefer the

--- a/docs/source/nodes/storage.rst
+++ b/docs/source/nodes/storage.rst
@@ -1,0 +1,21 @@
+STORAGE
+=======
+
+STORAGE is the earlier-generation recording node.  It saves data from a set of
+source nodes to a ``.tha`` capture file.  New experiments should prefer the
+:doc:`STORAGE2 <storage2>` node, which adds per-modality selection, file copying,
+and structured metadata; STORAGE is retained for compatibility with existing
+configurations.
+
+Properties
+----------
+
+* **Sources**: The nodes whose data is recorded.
+* **Output File**: The base name of the output file (the recording suffix is appended
+  as with STORAGE2).
+* **Compress Analog**: Compress time-series data with zlib.
+* **Compress Video**: Compress image data with H.264.
+* **Running**: Begin recording.
+
+While running, the node reports its output queue depth (**Output Queue Bytes** /
+**Output Queue Count**) as a backpressure indicator.

--- a/docs/source/nodes/storage.rst
+++ b/docs/source/nodes/storage.rst
@@ -14,7 +14,7 @@ Properties
 * **Output File**: The base name of the output file (the recording suffix is appended
   as with STORAGE2).
 * **Compress Analog**: Compress time-series data with zlib.
-* **Compress Video**: Compress image data with H.264.
+* **Compress Video**: Compress image data with MPEG-4 video encoding.
 * **Running**: Begin recording.
 
 While running, the node reports its output queue depth (**Output Queue Bytes** /

--- a/docs/source/nodes/sync.rst
+++ b/docs/source/nodes/sync.rst
@@ -1,0 +1,23 @@
+SYNC
+====
+
+The SYNC node measures the timing alignment between pairs of channels coming from
+different nodes.  It is useful for quantifying latency and verifying that two data
+streams are synchronized (for example, a hardware trigger captured on two
+different acquisition devices).
+
+Usage
+-----
+
+The node widget holds a list of **Pairs**.  Use the add/remove controls to manage
+them.  Each pair compares one channel against another and has the following
+columns:
+
+* **Node 1** / **Channel 1**: The first node and channel.
+* **Node 2** / **Channel 2**: The second node and channel.
+* **Window (s)**: The time window over which the comparison is performed.
+* **Threshold**: The detection threshold used to identify the events that are aligned
+  across the two channels.
+
+For each pair the node emits the measured timing relationship as output data, which
+can be visualized or recorded like any other channel.

--- a/docs/source/nodes/sync.rst
+++ b/docs/source/nodes/sync.rst
@@ -1,5 +1,8 @@
 SYNC
 ====
+|ui|
+
+.. |ui| image:: sync_ui.png
 
 The SYNC node measures the timing alignment between pairs of channels coming from
 different nodes.  It is useful for quantifying latency and verifying that two data

--- a/docs/source/nodes/task_controller.rst
+++ b/docs/source/nodes/task_controller.rst
@@ -1,0 +1,13 @@
+TASK_CONTROLLER
+===============
+
+The TASK_CONTROLLER node connects Thalamus to an external behavioral
+task-controller service over gRPC.  When the node's Running state changes it tells
+the task controller to start or stop, so a behavioral paradigm can be driven in
+lockstep with data acquisition (for example via a RUNNER2 node).
+
+Properties
+----------
+
+* **Address**: The gRPC address of the task-controller service to connect to.
+* **Running**: Start or stop the connected task controller.

--- a/docs/source/nodes/test_pulse.rst
+++ b/docs/source/nodes/test_pulse.rst
@@ -1,0 +1,12 @@
+TEST_PULSE_NODE
+===============
+
+The ``TEST_PULSE_NODE`` is a diagnostic that emits test pulses and watches for them
+on a returning channel.  Like :doc:`LOOP_TEST <loop_test>` it is used to verify that
+a signal path is intact and to characterize its latency.
+
+Properties
+----------
+
+* **Input**: The channel on which the returning pulse is expected.
+* **Output**: The channel on which the test pulse is emitted.

--- a/docs/source/nodes/thread_pool.rst
+++ b/docs/source/nodes/thread_pool.rst
@@ -2,12 +2,11 @@ THREAD_POOL
 ===========
 
 The THREAD_POOL node exposes Thalamus's shared worker thread pool as a node.  It is
-a system/diagnostic node: it lets you observe and control the pool that background
-work is dispatched to.
+a system/diagnostic node that lets you observe the pool that background work is
+dispatched to.
 
 Properties
 ----------
 
-* **Running**: Whether the pool is active.
-* **Idle Threads**: The number of currently idle worker threads (reported as a
-  diagnostic).
+* **Idle Threads**: The number of currently idle worker threads, sampled and
+  reported continuously as a diagnostic.

--- a/docs/source/nodes/thread_pool.rst
+++ b/docs/source/nodes/thread_pool.rst
@@ -1,0 +1,13 @@
+THREAD_POOL
+===========
+
+The THREAD_POOL node exposes Thalamus's shared worker thread pool as a node.  It is
+a system/diagnostic node: it lets you observe and control the pool that background
+work is dispatched to.
+
+Properties
+----------
+
+* **Running**: Whether the pool is active.
+* **Idle Threads**: The number of currently idle worker threads (reported as a
+  diagnostic).

--- a/docs/source/nodes/toggle.rst
+++ b/docs/source/nodes/toggle.rst
@@ -1,14 +1,18 @@
 TOGGLE
 ======
 
-The TOGGLE node is a transformer that converts an analog signal into a binary
-0/1 state by comparing it against a threshold.  It is useful for turning a
-continuous signal (such as a button voltage or a detector output) into a clean
-digital event channel.
+The TOGGLE node is a transformer that behaves like a flip-flop driven by an analog
+signal.  Each time the input makes a debounced rising crossing of the threshold, the
+node flips its output state.  This turns a stream of pulses (such as repeated button
+presses) into a latched on/off signal.
 
 Properties
 ----------
 
 * **Source**: The node supplying the input samples.
-* **Threshold**: The comparison level.  Samples on one side of the threshold produce
-  ``0`` and samples on the other side produce ``1``.
+* **Threshold**: The level the input must rise through to trigger a toggle.  A
+  debounce interval prevents a single noisy edge from toggling repeatedly.
+
+The output is ``3.3`` when the node is in its "on" state and ``0`` when it is "off".
+The state changes only on rising threshold crossings, so the same input level can
+correspond to either output depending on the toggle history.

--- a/docs/source/nodes/toggle.rst
+++ b/docs/source/nodes/toggle.rst
@@ -1,0 +1,14 @@
+TOGGLE
+======
+
+The TOGGLE node is a transformer that converts an analog signal into a binary
+0/1 state by comparing it against a threshold.  It is useful for turning a
+continuous signal (such as a button voltage or a detector output) into a clean
+digital event channel.
+
+Properties
+----------
+
+* **Source**: The node supplying the input samples.
+* **Threshold**: The comparison level.  Samples on one side of the threshold produce
+  ``0`` and samples on the other side produce ``1``.

--- a/docs/source/nodes/touch_screen.rst
+++ b/docs/source/nodes/touch_screen.rst
@@ -1,5 +1,8 @@
 TOUCH_SCREEN
 ============
+|ui|
+
+.. |ui| image:: touch_screen_ui.png
 
 The TOUCH_SCREEN node maps raw touch coordinates produced by a touch device into
 calibrated screen coordinates.  It consumes a stream of raw ``(X, Y)`` points and

--- a/docs/source/nodes/touch_screen.rst
+++ b/docs/source/nodes/touch_screen.rst
@@ -1,0 +1,30 @@
+TOUCH_SCREEN
+============
+
+The TOUCH_SCREEN node maps raw touch coordinates produced by a touch device into
+calibrated screen coordinates.  It consumes a stream of raw ``(X, Y)`` points and
+produces a transformed ``(X, Y)`` stream.
+
+Properties
+----------
+
+* **Method**: The calibration model used to map raw points to screen points.
+
+  * ``Matrix Multiplication (3-point)``: Solves a 3-point affine transform.
+  * ``Linear Regression (4-point)``: Fits a least-squares mapping from 4 points.
+* **Monitor**: Index of the monitor the touch surface corresponds to.
+* **Transform**: The current transform (3×3 matrix) applied to incoming points.  It
+  is populated automatically by the calibration routine but can also be inspected
+  directly.
+
+Calibration
+-----------
+
+The node widget provides **Calibrate** and **Test** buttons.
+
+* **Calibrate**: Walks you through touching a sequence of on-screen targets
+  (3 or 4 depending on the selected Method).  After each target, press any key to
+  advance.  When all targets have been collected the ``Transform`` is computed and
+  stored in the node's configuration.
+* **Test**: Lets you verify the resulting calibration by touching the screen and
+  observing where the mapped point lands.

--- a/docs/source/nodes/video.rst
+++ b/docs/source/nodes/video.rst
@@ -1,0 +1,17 @@
+VIDEO
+=====
+
+The VIDEO node is a generator that plays a video file and republishes its frames as
+an image stream.  Use it to feed recorded footage into a pipeline -- for example to
+replay a session through image-processing nodes such as OCULOMATIC or ARUCO.
+
+Properties
+----------
+
+* **File Name**: Path to the video file to play.
+* **Framerate**: The rate at which frames are emitted.
+* **Running**: Begin playback.
+
+The node reports its measured throughput (``BPS``) while running.  For ingesting
+live capture devices or a wider range of container/codec inputs, see the
+:doc:`FFMPEG <ffmpeg>` node.

--- a/docs/source/nodes/video.rst
+++ b/docs/source/nodes/video.rst
@@ -9,9 +9,9 @@ Properties
 ----------
 
 * **File Name**: Path to the video file to play.
-* **Framerate**: The rate at which frames are emitted.
 * **Running**: Begin playback.
 
-The node reports its measured throughput (``BPS``) while running.  For ingesting
+The node plays back at the file's native frame timing and reports the resulting
+``Framerate`` and its measured throughput (``BPS``) while running.  For ingesting
 live capture devices or a wider range of container/codec inputs, see the
 :doc:`FFMPEG <ffmpeg>` node.

--- a/docs/source/nodes/wallclock.rst
+++ b/docs/source/nodes/wallclock.rst
@@ -1,0 +1,16 @@
+WALLCLOCK
+=========
+
+The WALLCLOCK node is a generator that emits the current time as an analog time
+series.  It is primarily used as a synchronization reference so that a recording
+can be aligned to an absolute clock.
+
+Properties
+----------
+
+* **Type**: The clock source to read.
+
+  * ``System``: The local system clock.
+  * ``NTP``: A network time (NTP) source.
+  * ``PTP``: A Precision Time Protocol source.
+* **Integer Values**: Emit the time as integer values instead of floating point.

--- a/docs/source/nodes/xsens.rst
+++ b/docs/source/nodes/xsens.rst
@@ -1,0 +1,19 @@
+XSENS
+=====
+
+The XSENS node streams motion-capture pose data and republishes it as a motion
+(MOCAP) stream of body segments, each with a position and a quaternion rotation.
+It can connect to an Xsens motion-capture source.
+
+Properties
+----------
+
+* **Xsens Address**: Address of the motion-capture data source (default
+  ``127.0.0.1:6004``).
+* **Hand**: Which hand the pose corresponds to (``Left`` or ``Right``).
+* **Send Type**: How pose data is sampled/sent (e.g. ``Current``).
+* **Actor**: The actor index to stream when multiple actors are present.
+* **Poses**: A list of poses to publish, each identified by a segment id and name.
+
+The published segments can be recorded by a STORAGE2 node (via its **Motion**
+modality) and consumed by downstream nodes such as HEXASCOPE.

--- a/docs/source/nodes/xsens.rst
+++ b/docs/source/nodes/xsens.rst
@@ -1,5 +1,8 @@
 XSENS
 =====
+|ui|
+
+.. |ui| image:: xsens_ui.png
 
 The XSENS node streams motion-capture pose data and republishes it as a motion
 (MOCAP) stream of body segments, each with a position and a quaternion rotation.
@@ -11,9 +14,12 @@ Properties
 * **Xsens Address**: Address of the motion-capture data source (default
   ``127.0.0.1:6004``).
 * **Hand**: Which hand the pose corresponds to (``Left`` or ``Right``).
-* **Send Type**: How pose data is sampled/sent (e.g. ``Current``).
+* **Send Type**: How the pose value is reduced before sending -- ``Send Current``,
+  ``Send Max``, or ``Send Min``.
 * **Actor**: The actor index to stream when multiple actors are present.
-* **Poses**: A list of poses to publish, each identified by a segment id and name.
+* **Poses**: A list of poses to publish.  Each pose pairs a segment **Mask** with a
+  **Name**; use **Add Pose** / **Remove Pose** to manage the list.
 
+The **Reset** and **Cache** buttons clear and persist the node's tracked calibration.
 The published segments can be recorded by a STORAGE2 node (via its **Motion**
 modality) and consumed by downstream nodes such as HEXASCOPE.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -22,9 +22,14 @@ First, create a python virtual environment and activate it.  This is commonly ne
 
 From the releases page download the whl file for your platform and install it.  https://github.com/cajigaslab/Thalamus/releases
 
+.. note::
+
+   The distributed package is named ``thalamus_neuro`` (the importable Python module remains ``thalamus``).
+   Builds are published for Linux (manylinux), Windows, and macOS (arm64).
+
 .. code-block::
 
-   python -m pip install thalamus-0.3.37-py3-none-manylinux_2_27_x86_64.whl 
+   python -m pip install thalamus_neuro-1.0.15-py3-none-manylinux_2_39_x86_64.whl
 
 You should now be able to run the pipeline program and see a window appear with an empty node list.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,11 @@ All scripts assume Thalamus is installed (`pip install thalamus_neuro`).
 | --- | --- |
 | [`synthetic_recording.py`](synthetic_recording.py) | Generate a synthetic `.tha` capture file (a 2 Hz sine and a 1 Hz square pulse) with no acquisition hardware. |
 | [`analyze_recording.py`](analyze_recording.py) | Read a `.tha` file with `thalamus.record_reader2` and plot its analog channels. |
+| [`event_markers.py`](event_markers.py) | Record discrete behavioral event markers as `text` records alongside an analog channel. |
+| [`synthetic_video.py`](synthetic_video.py) | Record a synthetic grayscale video stream as `image` records and extract a frame to PNG. |
+| [`multinode_recording.py`](multinode_recording.py) | Record several nodes into one file and export each by name. |
+| [`capture_summary.py`](capture_summary.py) | Summarize any `.tha` file: nodes, data types, channels, duration, and metadata. |
+| [`closed_loop_latency.py`](closed_loop_latency.py) | Recover the latency between a trigger and its response by pairing rising edges. |
 
 ## Quick start (no hardware required)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+# Thalamus examples
+
+Runnable, copy-paste examples that accompany the
+[documentation](https://cajigaslab.github.io/Thalamus/examples/index.html).
+
+All scripts assume Thalamus is installed (`pip install thalamus_neuro`).
+
+| Script | What it does |
+| --- | --- |
+| [`synthetic_recording.py`](synthetic_recording.py) | Generate a synthetic `.tha` capture file (a 2 Hz sine and a 1 Hz square pulse) with no acquisition hardware. |
+| [`analyze_recording.py`](analyze_recording.py) | Read a `.tha` file with `thalamus.record_reader2` and plot its analog channels. |
+
+## Quick start (no hardware required)
+
+```bash
+# 1. Create a synthetic recording
+python synthetic_recording.py -o demo.tha
+
+# 2. Plot the channels straight from the .tha file
+python analyze_recording.py demo.tha -n wave -o analysis.png
+
+# 3. Export a node's data to CSV (or parquet, etc.)
+python -m thalamus.dataframe -n wave -i demo.tha -f csv -o demo.csv
+
+# 4. Or hydrate the whole capture into an HDF5 file for analysis
+python -m thalamus.hydrate demo.tha
+```
+
+See the [Examples page](https://cajigaslab.github.io/Thalamus/examples/index.html)
+in the documentation for a full walkthrough.

--- a/examples/analyze_recording.py
+++ b/examples/analyze_recording.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Read a Thalamus capture (``.tha``) file and plot its analog channels.
+
+This demonstrates reading raw records directly with ``thalamus.record_reader2``
+(no hydration step required) and reconstructing per-channel time series.  It works
+on the file produced by ``synthetic_recording.py`` or on any real recording.
+
+Usage::
+
+    python examples/analyze_recording.py synthetic.tha.20260602.1
+    python examples/analyze_recording.py recording.tha.20260602.1 -n wave -o plot.png
+"""
+import argparse
+import collections
+import pathlib
+
+import numpy
+import matplotlib
+matplotlib.use("Agg")          # render without a display
+import matplotlib.pyplot as plt
+
+from thalamus.record_reader2 import SimpleRecordReader
+
+
+def read_channels(path: pathlib.Path, node: str):
+    """Return {channel_name: numpy array} and the sample interval (ns)."""
+    channels = collections.defaultdict(list)
+    interval_ns = None
+    with SimpleRecordReader(str(path)) as reader:
+        for record in reader:
+            if record.WhichOneof("body") != "analog" or record.node != node:
+                continue
+            analog = record.analog
+            for interval, span in zip(analog.sample_intervals, analog.spans):
+                interval_ns = interval_ns or interval
+                channels[span.name].extend(analog.data[span.begin:span.end])
+    return {name: numpy.asarray(values) for name, values in channels.items()}, interval_ns
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=pathlib.Path, help="input .tha file")
+    parser.add_argument("-n", "--node", default="wave", help="node name to plot")
+    parser.add_argument("-o", "--output", type=pathlib.Path, default=pathlib.Path("analysis.png"))
+    args = parser.parse_args()
+
+    channels, interval_ns = read_channels(args.input, args.node)
+    if not channels:
+        raise SystemExit(f"No analog data for node {args.node!r} in {args.input}")
+
+    dt = (interval_ns or 1) / 1e9
+    fig, ax = plt.subplots(figsize=(8, 3))
+    for name, values in channels.items():
+        ax.plot(numpy.arange(len(values)) * dt, values, label=name)
+        print(f"{name}: {len(values)} samples")
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("Amplitude")
+    ax.legend(loc="upper right")
+    fig.tight_layout()
+    fig.savefig(args.output, dpi=110)
+    print(f"Saved {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/capture_summary.py
+++ b/examples/capture_summary.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Print a summary of any Thalamus capture (``.tha``) file.
+
+A handy first step when you receive a recording: see which nodes it contains, what
+kind of data each produced, the analog channel names, the recording duration, and
+the metadata stored at the start.  Works on any ``.tha`` file, including the ones
+produced by the other examples.
+
+Usage::
+
+    python examples/capture_summary.py session.tha
+"""
+import argparse
+import collections
+import pathlib
+
+from thalamus.record_reader2 import SimpleRecordReader
+
+
+def summarize(path: pathlib.Path) -> None:
+    body_counts = collections.Counter()
+    node_bodies = collections.defaultdict(collections.Counter)
+    node_channels = collections.defaultdict(set)
+    metadata = []
+    t_min = t_max = None
+
+    with SimpleRecordReader(str(path)) as reader:
+        for record in reader:
+            body = record.WhichOneof("body")
+            body_counts[body] += 1
+            node_bodies[record.node][body] += 1
+            if record.time:
+                t_min = record.time if t_min is None else min(t_min, record.time)
+                t_max = record.time if t_max is None else max(t_max, record.time)
+            if body == "analog":
+                for span in record.analog.spans:
+                    node_channels[record.node].add(span.name)
+            elif body == "metadata":
+                metadata = [(kv.key, getattr(kv, kv.WhichOneof("value")))
+                            for kv in record.metadata.keyvalues if kv.WhichOneof("value")]
+
+    print(f"File: {path}")
+    print(f"Records: {sum(body_counts.values())}  {dict(body_counts)}")
+    if t_min is not None:
+        print(f"Duration: {(t_max - t_min) / 1e9:.3f} s")
+    if metadata:
+        print(f"Metadata: {metadata}")
+    print("Nodes:")
+    for node in sorted(node_bodies):
+        bodies = dict(node_bodies[node])
+        channels = sorted(node_channels[node])
+        extra = f"  channels={channels}" if channels else ""
+        print(f"  {node}: {bodies}{extra}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=pathlib.Path, help="input .tha file")
+    summarize(parser.parse_args().input)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/closed_loop_latency.py
+++ b/examples/closed_loop_latency.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Measure closed-loop latency between two pulse channels in a recording.
+
+A core use of Thalamus is quantifying the latency of a closed loop: a trigger fires
+and a downstream system responds some milliseconds later.  This example synthesizes
+a recording with a ``trigger`` channel and a ``response`` channel offset by a known
+delay, then recovers that delay by detecting and pairing rising edges -- the same
+analysis used for the closed-loop performance figures in the Thalamus paper
+(https://www.nature.com/articles/s44172-026-00646-z).
+
+Usage::
+
+    python examples/closed_loop_latency.py                 # synthesize + analyze
+    python examples/closed_loop_latency.py recording.tha   # analyze an existing file
+"""
+import argparse
+import collections
+import pathlib
+import statistics
+import tempfile
+
+from thalamus.thalamus_pb2 import StorageRecord, AnalogResponse, Span, Metadata, Pair
+from thalamus.record_writer import write_record
+from thalamus.record_reader2 import SimpleRecordReader
+
+SAMPLE_RATE = 1000
+INTERVAL_NS = int(1e9 / SAMPLE_RATE)
+
+
+def synthesize(path: pathlib.Path, delay_samples: int = 5, n: int = 5000) -> None:
+    """Write trigger + response square waves where response lags by delay_samples."""
+    with path.open("wb") as stream:
+        write_record(stream, StorageRecord(
+            node="storage", time=0,
+            metadata=Metadata(keyvalues=[Pair(key="Rec", integral=1)])))
+        produced, t_ns = 0, 0
+        while produced < n:
+            count = min(16, n - produced)
+            trig, resp = [], []
+            for i in range(count):
+                s = produced + i
+                trig.append(5.0 if (s // 500) % 2 == 1 else 0.0)
+                r = s - delay_samples
+                resp.append(5.0 if (r >= 0 and (r // 500) % 2 == 1) else 0.0)
+            produced += count
+            t_ns += count * INTERVAL_NS
+            write_record(stream, StorageRecord(
+                node="daq", time=t_ns,
+                analog=AnalogResponse(
+                    data=trig + resp,
+                    spans=[Span(begin=0, end=count, name="trigger"),
+                           Span(begin=count, end=2 * count, name="response")],
+                    sample_intervals=[INTERVAL_NS, INTERVAL_NS], time=t_ns)))
+
+
+def load(path: pathlib.Path, node: str):
+    """Return {channel: (values, sample_times_ns)} for one analog node."""
+    values = collections.defaultdict(list)
+    times = collections.defaultdict(list)
+    with SimpleRecordReader(str(path)) as reader:
+        for record in reader:
+            if record.WhichOneof("body") != "analog" or record.node != node:
+                continue
+            analog = record.analog
+            for interval, span in zip(analog.sample_intervals, analog.spans):
+                seg = list(analog.data[span.begin:span.end])
+                base = analog.time - (len(seg) - 1) * interval   # time of first sample
+                values[span.name].extend(seg)
+                times[span.name].extend(base + j * interval for j in range(len(seg)))
+    return {name: (values[name], times[name]) for name in values}
+
+
+def rising_edges(values, times, threshold=2.5):
+    return [times[i] for i in range(1, len(values))
+            if values[i - 1] < threshold <= values[i]]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", nargs="?", type=pathlib.Path,
+                        help="existing .tha file (synthesized if omitted)")
+    parser.add_argument("-n", "--node", default="daq")
+    parser.add_argument("--trigger", default="trigger")
+    parser.add_argument("--response", default="response")
+    args = parser.parse_args()
+
+    path = args.input
+    if path is None:
+        path = pathlib.Path(tempfile.mkdtemp()) / "loop.tha"
+        synthesize(path)
+        print(f"Synthesized {path} (response lags trigger by 5 ms)")
+
+    channels = load(path, args.node)
+    trig = rising_edges(*channels[args.trigger])
+    resp = rising_edges(*channels[args.response])
+    latencies = [(r - t) / 1e6 for t, r in zip(trig, resp)]   # ms
+
+    print(f"trigger edges: {len(trig)}, response edges: {len(resp)}")
+    if latencies:
+        print(f"latency (ms): mean={statistics.mean(latencies):.3f} "
+              f"std={statistics.pstdev(latencies):.3f} "
+              f"min={min(latencies):.3f} max={max(latencies):.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/event_markers.py
+++ b/examples/event_markers.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Record behavioral event markers (text records) in a Thalamus capture file.
+
+Many experiments interleave a continuous analog signal with discrete *event
+markers* -- short text labels such as ``trial_start`` or ``reward``.  Thalamus
+stores these as ``text`` records in the same ``.tha`` file as the analog data, so
+they share a common timeline.
+
+This example writes a recording containing five event markers on an ``events`` node
+plus a continuous ``reward`` analog channel on a ``daq`` node.  Afterwards you can
+export the markers with::
+
+    python -m thalamus.dataframe -n events -t text -i events.tha -f csv
+
+Usage::
+
+    python examples/event_markers.py -o events.tha
+"""
+import argparse
+import math
+import pathlib
+
+from thalamus.thalamus_pb2 import StorageRecord, AnalogResponse, Span, Text, Metadata, Pair
+from thalamus.record_writer import write_record
+
+MARKERS = ["trial_start", "cue_on", "cue_off", "reward", "trial_end"]
+SAMPLE_RATE = 1000
+INTERVAL_NS = int(1e9 / SAMPLE_RATE)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-o", "--output", type=pathlib.Path, default=pathlib.Path("events.tha"))
+    args = parser.parse_args()
+
+    with args.output.open("wb") as stream:
+        write_record(stream, StorageRecord(
+            node="task", time=0,
+            metadata=Metadata(keyvalues=[Pair(key="Rec", integral=1)])))
+
+        # One marker every 200 ms, with a continuous analog channel in between.
+        for i, label in enumerate(MARKERS):
+            marker_ns = (i + 1) * 200_000_000
+
+            # Emit ~200 ms of analog data leading up to this marker.
+            data = [math.sin(2 * math.pi * 5.0 * (marker_ns - INTERVAL_NS * j) / 1e9)
+                    for j in range(200)][::-1]
+            write_record(stream, StorageRecord(
+                node="daq", time=marker_ns,
+                analog=AnalogResponse(
+                    data=data,
+                    spans=[Span(begin=0, end=len(data), name="reward")],
+                    sample_intervals=[INTERVAL_NS], time=marker_ns)))
+
+            # Emit the event marker itself.
+            write_record(stream, StorageRecord(
+                node="events", time=marker_ns,
+                text=Text(text=label, time=marker_ns)))
+
+    print(f"Wrote {args.output} with {len(MARKERS)} event markers")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multinode_recording.py
+++ b/examples/multinode_recording.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Record several nodes into one capture file, then export each separately.
+
+A real Thalamus experiment records many nodes into a single ``.tha`` file -- for
+example an eye tracker, an EMG sensor, and a trigger channel all at once.  Each
+node's data is tagged with its node name, so analysis tools select a node by name.
+
+This example writes a recording with two analog nodes -- ``eye`` (channels ``x`` and
+``y``) and ``emg`` (channel ``ch0``) -- and prints the per-node export commands.
+
+Usage::
+
+    python examples/multinode_recording.py -o session.tha
+
+Then export each node independently::
+
+    python -m thalamus.dataframe -n eye -i session.tha -f csv -o eye.csv
+    python -m thalamus.dataframe -n emg -i session.tha -f csv -o emg.csv
+"""
+import argparse
+import math
+import pathlib
+
+from thalamus.thalamus_pb2 import StorageRecord, AnalogResponse, Span, Metadata, Pair
+from thalamus.record_writer import write_record
+
+SAMPLE_RATE = 1000
+POLL_MS = 16
+DURATION_S = 5
+INTERVAL_NS = int(1e9 / SAMPLE_RATE)
+SAMPLES_PER_POLL = SAMPLE_RATE * POLL_MS // 1000
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-o", "--output", type=pathlib.Path, default=pathlib.Path("session.tha"))
+    args = parser.parse_args()
+
+    total = SAMPLE_RATE * DURATION_S
+    with args.output.open("wb") as stream:
+        write_record(stream, StorageRecord(
+            node="storage", time=0,
+            metadata=Metadata(keyvalues=[Pair(key="Rec", integral=1)])))
+
+        produced, t_ns = 0, 0
+        while produced < total:
+            count = min(SAMPLES_PER_POLL, total - produced)
+            t_ns += count * INTERVAL_NS
+
+            eye_x, eye_y, emg = [], [], []
+            for i in range(count):
+                t = (produced + i) / SAMPLE_RATE
+                eye_x.append(math.sin(2 * math.pi * 0.5 * t))
+                eye_y.append(math.cos(2 * math.pi * 0.5 * t))
+                emg.append(abs(math.sin(2 * math.pi * 3.0 * t)))
+            produced += count
+
+            write_record(stream, StorageRecord(
+                node="eye", time=t_ns,
+                analog=AnalogResponse(
+                    data=eye_x + eye_y,
+                    spans=[Span(begin=0, end=count, name="x"),
+                           Span(begin=count, end=2 * count, name="y")],
+                    sample_intervals=[INTERVAL_NS, INTERVAL_NS], time=t_ns)))
+            write_record(stream, StorageRecord(
+                node="emg", time=t_ns,
+                analog=AnalogResponse(
+                    data=emg,
+                    spans=[Span(begin=0, end=count, name="ch0")],
+                    sample_intervals=[INTERVAL_NS], time=t_ns)))
+
+    print(f"Wrote {args.output} with nodes: eye (x, y), emg (ch0)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/synthetic_recording.py
+++ b/examples/synthetic_recording.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Generate a synthetic Thalamus capture (``.tha``) file with no hardware.
+
+This writes a recording that looks just like one produced by a STORAGE2 node:
+a leading metadata record followed by a series of analog records.  Two channels
+are generated -- a 2 Hz sine wave and a 1 Hz square pulse -- so you can exercise
+the rest of the Thalamus tooling (``record_reader2``, ``dataframe``, ``hydrate``)
+without any acquisition hardware attached.
+
+Usage::
+
+    python examples/synthetic_recording.py            # writes synthetic.tha.YYYYMMDD.1
+    python examples/synthetic_recording.py -o demo.tha # custom output path
+"""
+import math
+import argparse
+import datetime
+import pathlib
+
+from thalamus.thalamus_pb2 import StorageRecord, AnalogResponse, Span, Metadata, Pair
+from thalamus.record_writer import write_record
+
+SAMPLE_RATE = 1000   # Hz
+POLL_MS = 16         # how many milliseconds of data each record carries
+DURATION_S = 5       # length of the recording
+SINE_HZ = 2.0        # frequency of the sine channel
+PULSE_HZ = 1.0       # frequency of the square pulse channel
+INTERVAL_NS = int(1e9 / SAMPLE_RATE)
+SAMPLES_PER_POLL = SAMPLE_RATE * POLL_MS // 1000
+
+
+def default_output() -> pathlib.Path:
+    stamp = datetime.date.today().strftime("%Y%m%d")
+    return pathlib.Path(f"synthetic.tha.{stamp}.1")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-o", "--output", type=pathlib.Path, default=default_output(),
+                        help="output .tha file (default: synthetic.tha.<date>.1)")
+    parser.add_argument("-d", "--duration", type=float, default=DURATION_S,
+                        help="recording duration in seconds")
+    args = parser.parse_args()
+
+    total_samples = int(SAMPLE_RATE * args.duration)
+
+    with args.output.open("wb") as stream:
+        # First record: metadata announcing the recording number, as STORAGE2 does.
+        write_record(stream, StorageRecord(
+            node="storage", time=0,
+            metadata=Metadata(keyvalues=[Pair(key="Rec", integral=1)]),
+        ))
+
+        produced = 0
+        t_ns = 0
+        while produced < total_samples:
+            count = min(SAMPLES_PER_POLL, total_samples - produced)
+            sine, pulse = [], []
+            for i in range(count):
+                t = (produced + i) / SAMPLE_RATE
+                sine.append(math.sin(2 * math.pi * SINE_HZ * t))
+                pulse.append(5.0 if int(t * PULSE_HZ * 2) % 2 == 0 else 0.0)
+            produced += count
+            t_ns += count * INTERVAL_NS
+
+            # Channels are concatenated in `data`; each `Span` maps a slice to a channel.
+            write_record(stream, StorageRecord(
+                node="wave", time=t_ns,
+                analog=AnalogResponse(
+                    data=sine + pulse,
+                    spans=[Span(begin=0, end=count, name="sine"),
+                           Span(begin=count, end=2 * count, name="pulse")],
+                    sample_intervals=[INTERVAL_NS, INTERVAL_NS],
+                    time=t_ns,
+                ),
+            ))
+
+    print(f"Wrote {args.output} ({args.output.stat().st_size} bytes, "
+          f"{total_samples} samples/channel)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/synthetic_video.py
+++ b/examples/synthetic_video.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Record a synthetic grayscale video stream into a Thalamus capture file.
+
+Thalamus stores camera data as ``image`` records.  Each record carries the raw
+frame bytes plus its width, height, pixel format, and frame interval.  This
+example writes a short ``Gray`` (8-bit) clip of a vertical bar sweeping across the
+frame -- no camera required -- and then extracts one frame to a PNG so you can see
+how to decode image records with ``thalamus.record_reader2``.
+
+Usage::
+
+    python examples/synthetic_video.py -o video.tha --frame 15 --png frame.png
+"""
+import argparse
+import pathlib
+
+import numpy
+
+from thalamus.thalamus_pb2 import StorageRecord, Image
+from thalamus.record_writer import write_record
+from thalamus.record_reader2 import SimpleRecordReader
+
+WIDTH, HEIGHT, FRAMES = 64, 48, 30
+FRAME_INTERVAL_NS = 33_000_000   # ~30 fps
+
+
+def write_video(path: pathlib.Path) -> None:
+    with path.open("wb") as stream:
+        for frame in range(FRAMES):
+            buf = numpy.zeros((HEIGHT, WIDTH), dtype=numpy.uint8)
+            buf[:, int(frame / FRAMES * (WIDTH - 1))] = 255   # sweeping bar
+            write_record(stream, StorageRecord(
+                node="cam", time=frame * FRAME_INTERVAL_NS,
+                image=Image(data=[buf.tobytes()], width=WIDTH, height=HEIGHT,
+                            format=Image.Format.Gray, frame_interval=FRAME_INTERVAL_NS)))
+
+
+def extract_frame(path: pathlib.Path, index: int) -> numpy.ndarray:
+    with SimpleRecordReader(str(path)) as reader:
+        frames = [r for r in reader if r.WhichOneof("body") == "image"]
+    image = frames[index].image
+    return numpy.frombuffer(image.data[0], dtype=numpy.uint8).reshape(image.height, image.width)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-o", "--output", type=pathlib.Path, default=pathlib.Path("video.tha"))
+    parser.add_argument("--frame", type=int, default=15, help="frame index to extract")
+    parser.add_argument("--png", type=pathlib.Path, default=pathlib.Path("frame.png"))
+    args = parser.parse_args()
+
+    write_video(args.output)
+    print(f"Wrote {args.output} ({FRAMES} frames, {WIDTH}x{HEIGHT}, Gray)")
+
+    arr = extract_frame(args.output, args.frame)
+    try:
+        from PIL import Image as PImage
+        PImage.fromarray(arr).save(args.png)
+        print(f"Saved frame {args.frame} to {args.png}")
+    except ImportError:
+        print(f"Frame {args.frame}: shape={arr.shape}, bar at column {int(arr.argmax() % arr.shape[1])} "
+              "(install Pillow to save a PNG)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Brings the repository documentation into line with the latest release (v1.0.15) and substantially expands it. **Documentation-only** — no source or build changes.

## Highlights

**Release alignment**
- README, quickstart, and Sphinx `conf.py` updated to v1.0.15: package is published as `thalamus_neuro` (importable module remains `thalamus`), builds for Linux/Windows/macOS (arm64), corrected install/run commands, links to the hosted docs and the published paper.

**Node reference (complete)**
- New categorized node **catalog**, with names verified against `type_name()` in `src/thalamus/*.cpp`.
- A **detailed page for every one of the 41 node types**, with properties taken from each node's Qt widget and/or C++ config keys.
- **17 node pages** include authentic UI screenshots rendered from the real widgets; nodes whose widgets are empty without live hardware/servers were intentionally left without screenshots.

**Concepts & examples**
- New **Concepts/Architecture** page: the node pipeline and its four roles, the `StorageRecord` data model, the steady-clock time base, the `.tha` capture-file format, the read/convert tooling, distributed operation, and persistence.
- **7 runnable examples** (in `examples/`) plus a full examples walkthrough — each executed end-to-end (generate → inspect → export → hydrate → analyze), no hardware required.

**Project docs**
- Added `CONTRIBUTING.md` (repo layout, dev setup, how to add a node type, PR/release process).
- Added `CHANGELOG.md` (curated 1.0.x release highlights derived from history).

## Quality
Every batch of node documentation was adversarially fact-checked against the C++/Python source by a reviewer agent; flagged inaccuracies (e.g. CHESSBOARD is a generator not a detector, TOGGLE's flip-flop behavior, NIDAQ_OUT/HAND_ENGINE/STORAGE/FFMPEG details) were corrected. The Sphinx site builds cleanly throughout.

## Commits
1. update for v1.0.15, add node catalog and runnable examples
2. add node reference pages for hardware and scripting nodes
3. add 5 runnable examples and document 12 more node types
4. fix node descriptions flagged by review (chessboard, toggle, nidaq_out)
5. document remaining node types (final batch)
6. fix node descriptions flagged by review (final batch)
7. add node-widget screenshots and a CONTRIBUTING guide
8. add screenshots for 9 more node widgets and refine text to match
9. add CHANGELOG and a Concepts/Architecture overview page

https://claude.ai/code/session_01MAzXeAdNgB8gzEfjaBWh7Z