### PR TITLE
docs: fix Furo "table of contents" error on the Examples page

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -11,9 +11,6 @@ If you use Thalamus in your work, please cite our paper:
 acquisition <https://www.nature.com/articles/s44172-026-00646-z>`_
 (Communications Engineering, Nature).
 
-.. contents::
-   :local:
-
 .. note::
 
    The example scripts live in the `examples/ <https://github.com/cajigaslab/Thalamus/tree/main/examples>`_


### PR DESCRIPTION
The Examples page rendered a red error block: *"Adding a table of contents in Furo-based documentation is unnecessary, and does not work well with existing styling."*

Cause: the `.. contents:: :local:` directive at the top of `examples/index.rst`. Furo intentionally rejects it (it provides its own on-page TOC in the right sidebar).

Fix: remove the directive. Verified the error block no longer appears in the built page.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAzXeAdNgB8gzEfjaBWh7Z)_